### PR TITLE
Reworked the direct driver, start/finalize for cap drivers

### DIFF
--- a/gcl_sdk/agents/universal/clients/backend/base.py
+++ b/gcl_sdk/agents/universal/clients/backend/base.py
@@ -28,20 +28,58 @@ class AbstractBackendClient(abc.ABC):
     """
 
     @abc.abstractmethod
-    def get(self, resource: models.Resource) -> dict[str, tp.Any]:
-        """Get the resource value in dictionary format."""
+    def get(
+        self, resource: models.Resource
+    ) -> dict[str, tp.Any] | models.Resource | models.ResourceMixin:
+        """Get the resource.
+
+        The method can return resource in different formats:
+         - dictionary - raw data of the resource value
+         - Resource - ready to use resource model
+         - ResourceMixin - a custom model that extends ResourceMixin and
+            can be converted to Resource model.
+        """
 
     @abc.abstractmethod
-    def create(self, resource: models.Resource) -> dict[str, tp.Any]:
-        """Creates the resource. Returns the created resource."""
+    def create(
+        self, resource: models.Resource
+    ) -> dict[str, tp.Any] | models.Resource | models.ResourceMixin:
+        """Creates the resource. Returns the created resource.
+
+        The method can return resource in different formats:
+         - dictionary - raw data of the resource value
+         - Resource - ready to use resource model
+         - ResourceMixin - a custom model that extends ResourceMixin and
+            can be converted to Resource model.
+        """
 
     @abc.abstractmethod
-    def update(self, resource: models.Resource) -> dict[str, tp.Any]:
-        """Update the resource. Returns the updated resource."""
+    def update(
+        self, resource: models.Resource
+    ) -> dict[str, tp.Any] | models.Resource | models.ResourceMixin:
+        """Update the resource. Returns the updated resource.
+
+        The method can return resource in different formats:
+         - dictionary - raw data of the resource value
+         - Resource - ready to use resource model
+         - ResourceMixin - a custom model that extends ResourceMixin and
+            can be converted to Resource model.
+        """
 
     @abc.abstractmethod
-    def list(self, kind: str, **kwargs) -> list[dict[str, tp.Any]]:
-        """Lists all resources by kind."""
+    def list(
+        self, kind: str, **kwargs
+    ) -> tp.Collection[
+        dict[str, tp.Any] | models.Resource | models.ResourceMixin
+    ]:
+        """Lists all resources by kind.
+
+        The method returns collection of resources in different formats:
+         - dictionary - raw data of the resource value
+         - Resource - ready to use resource model
+         - ResourceMixin - a custom model that extends ResourceMixin and
+            can be converted to Resource model.
+        """
 
     @abc.abstractmethod
     def delete(self, resource: models.Resource) -> None:

--- a/gcl_sdk/agents/universal/clients/backend/db.py
+++ b/gcl_sdk/agents/universal/clients/backend/db.py
@@ -1,0 +1,174 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import annotations
+
+import logging
+import typing as tp
+import uuid as sys_uuid
+
+from restalchemy.dm import filters as dm_filters
+from restalchemy.storage import exceptions as ra_exc
+from restalchemy.storage import base as ra_storage
+from gcl_sdk.agents.universal.clients.backend import base
+from gcl_sdk.agents.universal.clients.backend import exceptions as client_exc
+from gcl_sdk.agents.universal.dm import models
+
+
+LOG = logging.getLogger(__name__)
+
+
+class ModelSpec(tp.NamedTuple):
+    model: tp.Type[ra_storage.AbstractStorableMixin]
+    kind: str
+
+    # TODO(akremenetsky): Actually we can do filtering more flexibly
+    # by using any filters from restalchemy and not using the project_id.
+    project_id: sys_uuid.UUID
+
+    @classmethod
+    def from_collection(
+        cls,
+        collection: tp.Collection[tuple[tp.Type, str]],
+        project_id: sys_uuid.UUID,
+    ) -> tuple[ModelSpec, ...]:
+        return tuple(
+            cls(
+                model=model,
+                kind=kind,
+                project_id=project_id,
+            )
+            for model, kind in collection
+        )
+
+
+class DatabaseBackendClient(base.AbstractBackendClient):
+    """Database backend client."""
+
+    def __init__(
+        self,
+        model_specs: tp.Collection[ModelSpec],
+        session: tp.Any | None = None,
+    ):
+        super().__init__()
+        self._session = session
+        self._model_spec_map = {m.kind: m for m in model_specs}
+
+    def set_session(self, session: tp.Any) -> None:
+        """Set the session to be used by the client."""
+        self._session = session
+
+    def clear_session(self) -> None:
+        """Clear the session."""
+        self._session = None
+
+    def get(self, resource: models.Resource) -> models.ResourceMixin:
+        """Find and return a resource by uuid and kind."""
+        model_spec = self._model_spec_map[resource.kind]
+
+        try:
+            return model_spec.model.objects.get_one(
+                session=self._session,
+                filters={
+                    "uuid": dm_filters.EQ(str(resource.uuid)),
+                    "project_id": dm_filters.EQ(str(model_spec.project_id)),
+                },
+            )
+        except ra_exc.RecordNotFound:
+            LOG.exception(
+                "Unable to find %s %s", str(model_spec), resource.uuid
+            )
+            raise client_exc.ResourceNotFound(resource=resource)
+
+    def list(self, capability: str) -> list[models.ResourceMixin]:
+        """Lists all resources by capability."""
+        model_spec = self._model_spec_map[capability]
+
+        # Get all objects for the project from the database
+        return model_spec.model.objects.get_all(
+            session=self._session,
+            filters={
+                "project_id": dm_filters.EQ(str(model_spec.project_id)),
+            },
+        )
+
+    def create(self, resource: models.Resource) -> models.ResourceMixin:
+        """Creates a resource."""
+        model_spec = self._model_spec_map[resource.kind]
+
+        # Check if the resource already exists
+        # We need to do this check since PG does not correctly handle
+        # the case when the resource already exists and fails the transaction
+        obj = model_spec.model.objects.get_one_or_none(
+            session=self._session,
+            filters={
+                "uuid": dm_filters.EQ(str(resource.uuid)),
+                "project_id": dm_filters.EQ(str(model_spec.project_id)),
+            },
+        )
+        if obj is not None:
+            LOG.warning("The resource already exists: %s", resource.uuid)
+            raise client_exc.ResourceAlreadyExists(resource=resource)
+
+        # Save to db
+        obj = model_spec.model.from_ua_resource(resource)
+        obj.insert(session=self._session)
+
+        return obj
+
+    def update(self, resource: models.Resource) -> models.ResourceMixin:
+        """Update the resource."""
+        model_spec = self._model_spec_map[resource.kind]
+
+        # Check if the resource already exists
+        obj = model_spec.model.objects.get_one_or_none(
+            session=self._session,
+            filters={
+                "uuid": dm_filters.EQ(str(resource.uuid)),
+                "project_id": dm_filters.EQ(str(model_spec.project_id)),
+            },
+        )
+        if obj is None:
+            LOG.warning("The resource does not exist: %s", resource.uuid)
+            raise client_exc.ResourceNotFound(resource=resource)
+
+        updated_obj = model_spec.model.from_ua_resource(resource)
+
+        # Update the object
+        for field_name in resource.value.keys():
+            prop = obj.properties.get(field_name)
+            if not prop or prop.is_read_only():
+                continue
+            setattr(obj, field_name, getattr(updated_obj, field_name))
+        obj.update(session=self._session)
+
+        return obj
+
+    def delete(self, resource: models.Resource) -> None:
+        """Delete the resource."""
+        model_spec = self._model_spec_map[resource.kind]
+
+        try:
+            obj = model_spec.model.objects.get_one(
+                session=self._session,
+                filters={
+                    "uuid": dm_filters.EQ(str(resource.uuid)),
+                    "project_id": dm_filters.EQ(str(model_spec.project_id)),
+                },
+            )
+            obj.delete(session=self._session)
+            LOG.debug("Deleted resource: %s", resource.uuid)
+        except ra_exc.RecordNotFound:
+            LOG.warning("The resource is already deleted: %s", resource.uuid)

--- a/gcl_sdk/agents/universal/drivers/base.py
+++ b/gcl_sdk/agents/universal/drivers/base.py
@@ -58,6 +58,30 @@ class AbstractCapabilityDriver(abc.ABC):
     def delete(self, resource: models.Resource) -> None:
         """Delete the resource."""
 
+    def start(self) -> None:
+        """Perform some initialization before starting any operations.
+
+        This method is called once before any other method like list,
+        create, update, delete are called. It can be used to do some
+        preparations like establishing connections, opening files, etc.
+
+        The driver iteration:
+            start -> list -> [create | update | delete]* -> finalize
+        """
+        pass
+
+    def finalize(self) -> None:
+        """Perform some finalization after finishing all operations.
+
+        This method is called once after all other methods like list,
+        create, update, delete are called. It can be used to do some
+        finalization or cleanups like closing connections, files, etc.
+
+        The driver iteration:
+            start -> list -> [create | update | delete]* -> finalize
+        """
+        pass
+
 
 class AbstractFactDriver(abc.ABC):
     """Abstract driver for facts.

--- a/gcl_sdk/agents/universal/storage/base.py
+++ b/gcl_sdk/agents/universal/storage/base.py
@@ -17,36 +17,58 @@ from __future__ import annotations
 
 import abc
 import typing as tp
+import uuid as sys_uuid
 
 from gcl_sdk.agents.universal.dm import models
 
 
-class AbstractAgentStorage(abc.ABC):
-    """Abstract agent storage."""
+class TargetFieldItem(tp.NamedTuple):
+    kind: str
+    uuid: sys_uuid.UUID
+    fields: frozenset[str]
+
+    @classmethod
+    def from_ua_resource(cls, resource: models.Resource) -> TargetFieldItem:
+        return cls(
+            resource.kind, resource.uuid, frozenset(resource.value.keys())
+        )
+
+
+class AbstractTargetFieldsStorage(abc.ABC):
+    """Abstract target fields storage.
+
+    Abstract class that represents a storage for target fields.
+    UUID of an item is unique across the kind.
+    """
 
     @abc.abstractmethod
-    def get(self, resource: models.Resource) -> dict[str, tp.Any]:
-        """Get the resource  item from the storage."""
+    def get(self, kind: str, uuid: sys_uuid.UUID) -> TargetFieldItem:
+        """Get the target fields item from the storage."""
 
     @abc.abstractmethod
     def create(
         self,
-        resource: models.Resource,
-        item: dict[str, tp.Any],
+        item: TargetFieldItem,
         force: bool = False,
-    ) -> dict[str, tp.Any]:
-        """Creates the resource item in the storage."""
+    ) -> TargetFieldItem:
+        """Creates the target fields item in the storage."""
 
     @abc.abstractmethod
-    def update(
-        self, resource: models.Resource, item: dict[str, tp.Any]
-    ) -> dict[str, tp.Any]:
-        """Update the resource item in the storage."""
+    def update(self, item: TargetFieldItem) -> TargetFieldItem:
+        """Update the target fields item in the storage."""
 
     @abc.abstractmethod
-    def list(self, kind: str) -> list[dict[str, tp.Any]]:
-        """Lists all resource items by kind."""
+    def list(self, kind: str) -> list[TargetFieldItem]:
+        """Lists all target fields items of a resource kind."""
 
     @abc.abstractmethod
-    def delete(self, resource: models.Resource, force: bool = False) -> None:
-        """Delete the resource item from the storage."""
+    def delete(self, item: TargetFieldItem, force: bool = False) -> None:
+        """Delete the target fields item from the storage."""
+
+    @abc.abstractmethod
+    def load(self) -> None:
+        """Load the storage."""
+
+    @abc.abstractmethod
+    def persist(self) -> None:
+        """Persist the storage."""

--- a/gcl_sdk/agents/universal/storage/common.py
+++ b/gcl_sdk/agents/universal/storage/common.py
@@ -1,0 +1,65 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import annotations
+
+import os
+import json
+import threading
+from pathlib import Path
+
+
+class JsonFileStorageSingleton(dict):
+    _instances = {}
+    _lock = threading.Lock()
+
+    def __new__(cls, storage_path: str):
+        if storage_path not in cls._instances:
+            with cls._lock:
+                if storage_path not in cls._instances:
+                    cls._instances[storage_path] = super(
+                        JsonFileStorageSingleton, cls
+                    ).__new__(cls)
+        return cls._instances[storage_path]
+
+    def __init__(self, storage_path: str):
+        self._storage_path = Path(storage_path)
+
+        super().__init__()
+        self.load()
+
+    def load(self) -> None:
+        """Load the storage from the file."""
+        if not os.path.exists(self._storage_path):
+            self.clear()
+            return
+
+        with open(self._storage_path) as f:
+            data = json.load(f)
+
+        self.clear()
+        self.update(data)
+
+    def persist(self) -> None:
+        """Persist the storage to the file."""
+
+        # Create the directory if it doesn't exist
+        os.makedirs(os.path.dirname(self._storage_path), exist_ok=True)
+
+        # Save the new data
+        tmp_file = self._storage_path.with_suffix(".tmp")
+        with open(tmp_file, "w") as f:
+            json.dump(self, f, indent=2)
+        os.replace(tmp_file, self._storage_path)

--- a/gcl_sdk/agents/universal/storage/exceptions.py
+++ b/gcl_sdk/agents/universal/storage/exceptions.py
@@ -14,18 +14,18 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 from gcl_sdk.common import exceptions
-from gcl_sdk.agents.universal.dm import models
+from gcl_sdk.agents.universal.storage import base
 
 
-class AgentStorageException(exceptions.UniversalAgentException):
-    __template__ = "An unknown agent storage exception occurred."
+class TargetFieldsStorageException(exceptions.UniversalAgentException):
+    __template__ = "An unknown target fields storage exception occurred."
 
 
-class ResourceAlreadyExists(AgentStorageException):
-    __template__ = "The resource already exists: {resource}"
-    resource: models.Resource
+class ItemAlreadyExists(TargetFieldsStorageException):
+    __template__ = "The item already exists: {item}"
+    item: base.TargetFieldItem
 
 
-class ResourceNotFound(AgentStorageException):
-    __template__ = "The resource not found: {resource}"
-    resource: models.Resource
+class ItemNotFound(TargetFieldsStorageException):
+    __template__ = "The item not found: {item}"
+    item: base.TargetFieldItem

--- a/gcl_sdk/tests/unit/agents/drivers/test_direct_driver.py
+++ b/gcl_sdk/tests/unit/agents/drivers/test_direct_driver.py
@@ -1,0 +1,302 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import uuid as sys_uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+from gcl_sdk.agents.universal.drivers.direct import DirectAgentDriver
+from gcl_sdk.agents.universal.drivers import exceptions as driver_exc
+from gcl_sdk.agents.universal.clients.backend import exceptions as client_exc
+from gcl_sdk.agents.universal.storage import exceptions as storage_exc
+from gcl_sdk.agents.universal.storage import base as storage_base
+from gcl_sdk.agents.universal.dm import models
+
+
+def _make_resource(
+    kind: str, uuid: sys_uuid.UUID | None = None, value: dict | None = None
+) -> models.Resource:
+    uuid = uuid or sys_uuid.uuid4()
+    value = value or {"uuid": str(uuid), "a": 1, "b": 2, "status": "ACTIVE"}
+    return models.Resource.from_value(
+        value, kind, target_fields=frozenset(value.keys())
+    )
+
+
+def _driver_with_caps(
+    client_mock: MagicMock, storage_mock: MagicMock, caps: list[str]
+):
+    class _Drv(DirectAgentDriver):
+        def get_capabilities(self) -> list[str]:
+            return caps
+
+    return _Drv(client=client_mock, storage=storage_mock)
+
+
+class TestDirectDriver:
+    def test_start_and_finalize(self):
+        client = MagicMock()
+        storage = MagicMock()
+
+        drv = _driver_with_caps(client, storage, caps=["config"])
+
+        drv.start()
+        storage.load.assert_called_once_with()
+
+        drv.finalize()
+        storage.persist.assert_called_once_with()
+
+    def test_validate_unsupported_kind_raises(self):
+        client = MagicMock()
+        storage = MagicMock()
+        drv = _driver_with_caps(
+            client, storage, caps=["config"]
+        )  # only 'config' supported
+
+        res = _make_resource("secret")
+
+        with pytest.raises(TypeError):
+            drv.get(res)
+
+        with pytest.raises(TypeError):
+            drv.create(res)
+
+        with pytest.raises(TypeError):
+            drv.update(res)
+
+        with pytest.raises(TypeError):
+            drv.list("secret")
+
+        with pytest.raises(TypeError):
+            drv.delete(res)
+
+    def test_get_success_when_client_and_storage_ok(self):
+        client = MagicMock()
+        storage = MagicMock()
+        drv = _driver_with_caps(client, storage, caps=["config"])
+
+        res = _make_resource("config")
+        tf_item = storage_base.TargetFieldItem(
+            kind=res.kind,
+            uuid=res.uuid,
+            fields=frozenset({"a", "b", "uuid", "status"}),
+        )
+
+        # Note: DirectAgentDriver.get currently
+        # calls storage.get(resource.uuid, resource.kind)
+        storage.get.return_value = tf_item
+        client_value = {
+            "uuid": str(res.uuid),
+            "a": 10,
+            "b": 20,
+            "status": "ACTIVE",
+        }
+        client.get.return_value = client_value
+
+        actual = drv.get(res)
+
+        # Ensure storage and client were called
+        assert storage.get.call_count == 1
+        client.get.assert_called_once_with(res)
+
+        assert isinstance(actual, models.Resource)
+        assert actual.uuid == res.uuid
+        assert actual.kind == res.kind
+        assert actual.value == client_value
+
+    def test_get_not_found_maps_exceptions(self):
+        client = MagicMock()
+        storage = MagicMock()
+        drv = _driver_with_caps(client, storage, caps=["config"])
+
+        res = _make_resource("config")
+
+        # storage raises -> driver maps to ResourceNotFound
+        storage.get.side_effect = storage_exc.ItemNotFound(item=None)  # type: ignore[arg-type]
+        with pytest.raises(driver_exc.ResourceNotFound):
+            drv.get(res)
+
+        # client raises -> driver maps to ResourceNotFound
+        storage.get.reset_mock()
+        storage.get.return_value = storage_base.TargetFieldItem(
+            res.kind, res.uuid, frozenset(res.value.keys())
+        )
+        client.get.side_effect = client_exc.ResourceNotFound(resource=res)  # type: ignore[arg-type]
+        with pytest.raises(driver_exc.ResourceNotFound):
+            drv.get(res)
+
+    def test_list_collects_intersection_of_storage_and_client(self):
+        client = MagicMock()
+        storage = MagicMock()
+        drv = _driver_with_caps(client, storage, caps=["config"])
+
+        # Storage has two items
+        uuid1, uuid2, uuid3 = (
+            sys_uuid.uuid4(),
+            sys_uuid.uuid4(),
+            sys_uuid.uuid4(),
+        )
+        s_item1 = storage_base.TargetFieldItem(
+            "config", uuid1, frozenset({"a", "b", "uuid"})
+        )
+        s_item2 = storage_base.TargetFieldItem(
+            "config", uuid2, frozenset({"a", "b", "uuid"})
+        )
+        storage.list.return_value = [s_item1, s_item2]
+
+        # Client returns: one dict that matches storage (uuid1),
+        # one Resource that doesn't have a storage entry (uuid3),
+        # and one dict for uuid2 also matches storage.
+        client_list = [
+            {"uuid": str(uuid1), "a": 1, "b": 2},
+            models.Resource.from_value(
+                {"uuid": str(uuid3), "a": 3, "b": 4}, "config", s_item2.fields
+            ),
+            {"uuid": str(uuid2), "a": 5, "b": 6},
+        ]
+        client.list.return_value = client_list
+
+        resources = drv.list("config")
+
+        # Only items with both client and storage
+        # should be returned (uuid1, uuid2)
+        uuids = {r.uuid for r in resources}
+        assert uuids == {uuid1, uuid2}
+        assert all(r.kind == "config" for r in resources)
+
+        storage.list.assert_called_once_with("config")
+        client.list.assert_called_once_with("config")
+
+    def test_create_success_and_storage_create_called_before_client(self):
+        client = MagicMock()
+        storage = MagicMock()
+        drv = _driver_with_caps(client, storage, caps=["config"])
+
+        res = _make_resource("config")
+        client_resp = {
+            "uuid": str(res.uuid),
+            "a": 100,
+            "b": 200,
+            "status": "ACTIVE",
+        }
+        client.create.return_value = client_resp
+
+        actual = drv.create(res)
+
+        # storage.create called with TargetFieldItem and force=True
+        assert storage.create.call_count == 1
+        args, kwargs = storage.create.call_args
+        assert isinstance(args[0], storage_base.TargetFieldItem)
+        assert kwargs == {"force": True}
+
+        # client.create called with resource
+        client.create.assert_called_once_with(res)
+
+        # Check result resource corresponds to client response
+        assert actual.uuid == res.uuid
+        assert actual.kind == res.kind
+        assert actual.value == client_resp
+
+        # Do not assert strict cross-mock ordering; just ensure both were called
+
+    def test_create_maps_already_exists_exception(self):
+        client = MagicMock()
+        storage = MagicMock()
+        drv = _driver_with_caps(client, storage, caps=["config"])
+
+        res = _make_resource("config")
+        client.create.side_effect = client_exc.ResourceAlreadyExists(resource=res)  # type: ignore[arg-type]
+
+        with pytest.raises(driver_exc.ResourceAlreadyExists):
+            drv.create(res)
+
+    def test_update_success(self):
+        client = MagicMock()
+        storage = MagicMock()
+        drv = _driver_with_caps(client, storage, caps=["config"])
+
+        res = _make_resource("config")
+        client_resp = {
+            "uuid": str(res.uuid),
+            "a": 11,
+            "b": 22,
+            "status": "ACTIVE",
+        }
+        client.update.return_value = client_resp
+
+        actual = drv.update(res)
+
+        # storage.update called with TargetFieldItem
+        assert storage.update.call_count == 1
+        args, _ = storage.update.call_args
+        assert isinstance(args[0], storage_base.TargetFieldItem)
+
+        client.update.assert_called_once_with(res)
+        assert actual.value == client_resp
+
+    def test_update_maps_not_found_exception(self):
+        client = MagicMock()
+        storage = MagicMock()
+        drv = _driver_with_caps(client, storage, caps=["config"])
+
+        res = _make_resource("config")
+        client.update.side_effect = client_exc.ResourceNotFound(resource=res)  # type: ignore[arg-type]
+
+        with pytest.raises(driver_exc.ResourceNotFound):
+            drv.update(res)
+
+    def test_delete_calls_client_and_storage_even_if_client_not_found(self):
+        client = MagicMock()
+        storage = MagicMock()
+        drv = _driver_with_caps(client, storage, caps=["config"])
+
+        res = _make_resource("config")
+
+        # Case 1: normal delete
+        drv.delete(res)
+        client.delete.assert_called_once_with(res)
+        # Ensure storage.delete was called with force=True and matching identity
+        assert storage.delete.call_count == 1
+        del_args, del_kwargs = storage.delete.call_args
+        assert del_kwargs == {"force": True}
+        item = del_args[0]
+        if isinstance(item, storage_base.TargetFieldItem):
+            assert item.kind == res.kind and item.uuid == res.uuid
+        else:
+            assert (
+                getattr(item, "kind", None) == res.kind
+                and getattr(item, "uuid", None) == res.uuid
+            )
+
+        # Case 2: client raises not found, storage.delete still called
+        client.delete.reset_mock()
+        storage.delete.reset_mock()
+        client.delete.side_effect = client_exc.ResourceNotFound(resource=res)  # type: ignore[arg-type]
+
+        drv.delete(res)
+
+        client.delete.assert_called_once_with(res)
+        assert storage.delete.call_count == 1
+        del_args, del_kwargs = storage.delete.call_args
+        assert del_kwargs == {"force": True}
+        item = del_args[0]
+        if isinstance(item, storage_base.TargetFieldItem):
+            assert item.kind == res.kind and item.uuid == res.uuid
+        else:
+            assert (
+                getattr(item, "kind", None) == res.kind
+                and getattr(item, "uuid", None) == res.uuid
+            )

--- a/gcl_sdk/tests/unit/agents/drivers/test_meta_driver.py
+++ b/gcl_sdk/tests/unit/agents/drivers/test_meta_driver.py
@@ -1,0 +1,232 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import json
+import os
+import uuid as sys_uuid
+
+import pytest
+
+from gcl_sdk.agents.universal.drivers import exceptions as driver_exc
+from gcl_sdk.agents.universal.drivers import meta
+from gcl_sdk.agents.universal.dm import models
+from restalchemy.dm import properties
+from restalchemy.dm import types
+
+
+def _make_resource(
+    kind: str, uuid: sys_uuid.UUID | None = None, value: dict | None = None
+) -> models.Resource:
+    uuid = uuid or sys_uuid.uuid4()
+    value = value or {"uuid": str(uuid), "foo": 1}
+    return models.Resource.from_value(
+        value, kind, target_fields=frozenset(value.keys())
+    )
+
+
+class DummyModel(meta.MetaDataPlaneModel):
+    """A lightweight DP model for testing meta driver flows.
+
+    It records calls to DP-like methods in a class-level log.
+    """
+
+    call_log: dict[str, list[str]] = {}
+
+    # Custom fields that may appear in resource.value
+    foo = properties.property(types.Integer(), default=0)
+    raise_on_restore = properties.property(types.Boolean(), default=False)
+
+    def get_meta_model_fields(self) -> set[str] | None:
+        # Save all fields into meta file (including any service flags)
+        return None
+
+    def _log(self, action: str) -> None:
+        self.call_log.setdefault(str(self.uuid), []).append(action)
+
+    def dump_to_dp(self) -> None:  # create
+        self._log("dump_to_dp")
+
+    def restore_from_dp(self) -> None:  # get/list
+        # Optional flag to simulate not-found on DP for this object
+        if getattr(self, "raise_on_restore", False):
+            raise driver_exc.ResourceNotFound(
+                resource=models.Resource.from_value(
+                    {"uuid": str(self.uuid)}, "dummy", frozenset({"uuid"})
+                )
+            )
+        self._log("restore_from_dp")
+
+    def delete_from_dp(self) -> None:
+        self._log("delete_from_dp")
+
+    def update_on_dp(self) -> None:
+        self._log("update_on_dp")
+
+
+class _Driver(meta.MetaFileStorageAgentDriver):
+    __model_map__ = {"dummy": DummyModel}
+
+
+class TestMetaDriver:
+    def test_finalize_persists_meta_file(self, tmp_path):
+        meta_file = tmp_path / "meta.json"
+        drv = _Driver(meta_file=str(meta_file))
+
+        # Initially empty storage
+        assert drv._storage == {}
+
+        # Create one resource to populate meta storage
+        res = _make_resource("dummy")
+        drv.create(res)
+
+        # Persist to file
+        drv.finalize()
+
+        assert os.path.exists(meta_file)
+        with open(meta_file) as f:
+            data = json.load(f)
+        assert "dummy" in data and "resources" in data["dummy"]
+        assert str(res.uuid) in data["dummy"]["resources"]
+
+    def test_get_unsupported_kind_raises(self, tmp_path):
+        meta_file = tmp_path / "meta.json"
+        drv = _Driver(meta_file=str(meta_file))
+
+        res = _make_resource("other")
+        with pytest.raises(TypeError):
+            drv.get(res)
+
+    def test_get_not_found_raises(self, tmp_path):
+        meta_file = tmp_path / "meta.json"
+        drv = _Driver(meta_file=str(meta_file))
+
+        res = _make_resource("dummy")
+        with pytest.raises(driver_exc.ResourceNotFound):
+            drv.get(res)
+
+    def test_create_and_get_success(self, tmp_path):
+        meta_file = tmp_path / "meta.json"
+        drv = _Driver(meta_file=str(meta_file))
+
+        res = _make_resource("dummy")
+        created = drv.create(res)
+
+        assert created.uuid == res.uuid
+        assert created.kind == res.kind
+
+        fetched = drv.get(res)
+        assert fetched.uuid == res.uuid
+        assert fetched.kind == res.kind
+
+        # Ensure DP methods were called
+        log = DummyModel.call_log[str(res.uuid)]
+        assert "dump_to_dp" in log
+        assert "restore_from_dp" in log
+
+    def test_create_already_exists_maps_exception(self, tmp_path):
+        meta_file = tmp_path / "meta.json"
+        drv = _Driver(meta_file=str(meta_file))
+
+        res = _make_resource("dummy")
+        drv.create(res)
+
+        with pytest.raises(driver_exc.ResourceAlreadyExists):
+            drv.create(res)
+
+    def test_list_skips_objects_not_on_dp(self, tmp_path):
+        meta_file = tmp_path / "meta.json"
+        drv = _Driver(meta_file=str(meta_file))
+
+        # Create two resources, one will be marked to raise on restore
+        uuid1, uuid2 = sys_uuid.uuid4(), sys_uuid.uuid4()
+        res1 = _make_resource(
+            "dummy", uuid=uuid1, value={"uuid": str(uuid1), "foo": 1}
+        )
+        res2 = _make_resource(
+            "dummy",
+            uuid=uuid2,
+            value={"uuid": str(uuid2), "foo": 2, "raise_on_restore": True},
+        )
+
+        drv.create(res1)
+        drv.create(res2)
+
+        resources = drv.list("dummy")
+
+        # Only the one that could be restored from DP should be returned
+        assert len(resources) == 1
+        assert resources[0].uuid == uuid1
+        assert resources[0].kind == "dummy"
+
+    def test_update_success(self, tmp_path):
+        meta_file = tmp_path / "meta.json"
+        drv = _Driver(meta_file=str(meta_file))
+
+        res = _make_resource("dummy")
+
+        drv.create(res)
+
+        # Update with new value
+        new_value = {"uuid": str(res.uuid), "foo": 42}
+        new_res = models.Resource.from_value(
+            new_value, "dummy", target_fields=frozenset(new_value.keys())
+        )
+
+        updated = drv.update(new_res)
+
+        assert updated.uuid == res.uuid
+        assert updated.value["foo"] == 42
+
+        # Ensure update_on_dp called and meta was refreshed
+        log = DummyModel.call_log[str(res.uuid)]
+        assert "update_on_dp" in log
+
+        # The meta storage should contain updated value
+        meta_obj = drv._storage["dummy"]["resources"][str(res.uuid)]
+        assert meta_obj.get("foo") == 42
+
+    def test_update_not_found_maps_exception(self, tmp_path):
+        meta_file = tmp_path / "meta.json"
+        drv = _Driver(meta_file=str(meta_file))
+
+        # Not created in meta -> should raise
+        res = _make_resource("dummy")
+        with pytest.raises(driver_exc.ResourceNotFound):
+            drv.update(res)
+
+    def test_delete_success(self, tmp_path):
+        meta_file = tmp_path / "meta.json"
+        drv = _Driver(meta_file=str(meta_file))
+
+        res = _make_resource("dummy")
+        drv.create(res)
+
+        # Ensure present in meta
+        assert str(res.uuid) in drv._storage["dummy"]["resources"]
+
+        drv.delete(res)
+
+        # Ensure DP delete was called and meta entry removed
+        log = DummyModel.call_log[str(res.uuid)]
+        assert "delete_from_dp" in log
+        assert str(res.uuid) not in drv._storage["dummy"]["resources"]
+
+    def test_delete_unsupported_kind_raises(self, tmp_path):
+        meta_file = tmp_path / "meta.json"
+        drv = _Driver(meta_file=str(meta_file))
+
+        res = _make_resource("other")
+        with pytest.raises(TypeError):
+            drv.delete(res)

--- a/gcl_sdk/tests/unit/agents/drivers/test_storage_singleton.py
+++ b/gcl_sdk/tests/unit/agents/drivers/test_storage_singleton.py
@@ -17,35 +17,35 @@
 import json
 import os
 from unittest.mock import patch
-from gcl_sdk.agents.universal.drivers.meta import MetaFileStorageSingleton
+from gcl_sdk.agents.universal.storage import common as storage_common
 
 
 def test_storage_singleton_get_instance(tmp_path):
     meta_file = tmp_path / "test_meta.json"
 
-    instance1 = MetaFileStorageSingleton(meta_file)
-    instance2 = MetaFileStorageSingleton(meta_file)
+    instance1 = storage_common.JsonFileStorageSingleton(meta_file)
+    instance2 = storage_common.JsonFileStorageSingleton(meta_file)
 
     assert instance1 is instance2
-    assert isinstance(instance1, MetaFileStorageSingleton)
+    assert isinstance(instance1, storage_common.JsonFileStorageSingleton)
 
 
 def test_storage_singleton_get_instance_different(tmp_path):
     meta_file = tmp_path / "test_meta.json"
     meta_file2 = tmp_path / "test_meta2.json"
 
-    instance1 = MetaFileStorageSingleton(meta_file)
-    instance2 = MetaFileStorageSingleton(meta_file2)
+    instance1 = storage_common.JsonFileStorageSingleton(meta_file)
+    instance2 = storage_common.JsonFileStorageSingleton(meta_file2)
 
     assert instance1 is not instance2
-    assert isinstance(instance1, MetaFileStorageSingleton)
+    assert isinstance(instance1, storage_common.JsonFileStorageSingleton)
 
 
 def test_storage_singleton_load_non_existent_file(tmp_path):
     meta_file = tmp_path / "non_existent.json"
 
     with patch("os.path.exists", return_value=False):
-        storage = MetaFileStorageSingleton(meta_file)
+        storage = storage_common.JsonFileStorageSingleton(meta_file)
         storage.load()
 
     assert storage == {}
@@ -58,7 +58,7 @@ def test_storage_singleton_load_existing_file(tmp_path):
     with open(meta_file, "w") as f:
         json.dump(expected_data, f)
 
-    storage = MetaFileStorageSingleton(meta_file)
+    storage = storage_common.JsonFileStorageSingleton(meta_file)
     storage.load()
 
     assert storage == expected_data
@@ -69,7 +69,7 @@ def test_storage_singleton_persist(tmp_path):
     new_vals = {"key": "new_val"}
 
     with patch("os.makedirs") as mock_makedirs:
-        storage = MetaFileStorageSingleton(meta_file)
+        storage = storage_common.JsonFileStorageSingleton(meta_file)
         storage.update(new_vals)
         storage.persist()
 
@@ -86,7 +86,7 @@ def test_storage_singleton_persist_overwrite(tmp_path):
     meta_file = tmp_path / "test_persist.json"
     new_vals = {"key": "new_val"}
 
-    storage = MetaFileStorageSingleton(meta_file)
+    storage = storage_common.JsonFileStorageSingleton(meta_file)
     storage.update(new_vals)
     storage.persist()
 


### PR DESCRIPTION
Changes in this patch:
- Extened interface of AbstractCapabilityDriver with the start/finalize sections.
- New interface and storage implementation for DirectAgentDriver.
- Backend clients are able to work with Resource model and ResourceMixin models directly.
- Reworked the DirectAgentDriver. The driver was adapted to new storage interface AbstractTargetFieldsStorage and supported new model types from the backend clients.
- Added new cap. driver DatabaseCapabilityDriver. It's similar to RestCoreCapabilityDriver but words directly with database.
- Tests for DirectAgentDriver.
- Tests for MetaFileStorageAgentDriver.