### PR TITLE
Agent service based on DatabaseCapabilityDriver driver

### DIFF
--- a/gcl_sdk/agents/universal/cmd/universal_agent_db_back.py
+++ b/gcl_sdk/agents/universal/cmd/universal_agent_db_back.py
@@ -1,0 +1,203 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import logging
+import sys
+import typing as tp
+import collections
+import uuid as sys_uuid
+
+import bazooka
+from oslo_config import cfg
+from restalchemy.common import config_opts as ra_config_opts
+from restalchemy.storage.sql import engines
+from restalchemy.dm import filters as dm_filters
+
+from gcl_sdk.common import config
+from gcl_sdk.common import log as infra_log
+from gcl_sdk.agents.universal.services import agent
+from gcl_sdk.agents.universal import utils as ua_utils
+from gcl_sdk.agents.universal.clients.orch import db as orch_db
+from gcl_sdk.agents.universal.clients.orch import http as orch_http
+from gcl_sdk.agents.universal.clients.backend import db as db_back
+from gcl_sdk.agents.universal.drivers import core as ua_core_drivers
+
+DOMAIN = "agent"
+
+LOG = logging.getLogger(__name__)
+
+
+core_agent_opts = [
+    cfg.StrOpt(
+        "uuid",
+        default=None,
+        help=(
+            "UUID of the agent, if not provided, "
+            "the system UUID will be used"
+        ),
+    ),
+    cfg.StrOpt(
+        "uuid5_name",
+        default=None,
+        help=(
+            "UUID5 name component to generate UUID of the agent. "
+            "This option is ignored if the `uuid` is set."
+        ),
+    ),
+    cfg.StrOpt(
+        "project_id",
+        default=None,
+        help="Project ID to use for the core agent.",
+    ),
+    cfg.StrOpt(
+        "target_fields_path",
+        default="/var/lib/genesis/universal_agent/db_back_target_fields.json",
+        help="Path to the target fields storage file.",
+    ),
+    cfg.StrOpt(
+        "orch_client",
+        default="db",
+        help=("Orch client to use for the core agent. Can be 'db' or 'http'."),
+    ),
+    cfg.StrOpt(
+        "orch_endpoint",
+        default="http://localhost:11011",
+        help="Endpoint of Genesis Core Orch API for 'http' orch client",
+    ),
+    cfg.StrOpt(
+        "status_endpoint",
+        default="http://localhost:11012",
+        help="Endpoint of Genesis Core Status API for 'http' orch client",
+    ),
+    cfg.StrOpt(
+        "payload_path",
+        default=None,
+        help="Path to the payload file.",
+    ),
+]
+
+CONF = cfg.CONF
+ra_config_opts.register_posgresql_db_opts(CONF)
+CONF.register_cli_opts(core_agent_opts, DOMAIN)
+
+
+def load_filters(
+    project_id: str,
+) -> tp.DefaultDict[str, dict[str, dm_filters.AbstractClause]]:
+    # Default filter is project_id
+    filters = collections.defaultdict(
+        lambda: {"project_id": dm_filters.EQ(project_id)}
+    )
+
+    for kind, _filter in ua_utils.cfg_load_section_map(
+        CONF.config_file, "filters"
+    ).items():
+        # TODO(akremenetsky): Only simplest 'EQ' filter is supported
+        # for now. Add more complex filters support later.
+        field, value = _filter.split(":", 1)
+
+        filters[kind] = {field: dm_filters.EQ(value)}
+
+    LOG.info("Loaded filters: %s", filters)
+
+    return filters
+
+
+def main():
+    # Parse config
+    config.parse(sys.argv[1:])
+
+    # Configure logging
+    infra_log.configure()
+    log = logging.getLogger(__name__)
+
+    engines.engine_factory.configure_postgresql_factory(CONF)
+
+    # Detect the agent UUID.
+    if CONF[DOMAIN].uuid:
+        agent_uuid = sys_uuid.UUID(CONF[DOMAIN].uuid)
+    elif CONF[DOMAIN].uuid5_name:
+        agent_uuid = sys_uuid.uuid5(
+            ua_utils.system_uuid(), CONF[DOMAIN].uuid5_name
+        )
+    else:
+        agent_uuid = ua_utils.system_uuid()
+
+    if not CONF[DOMAIN].project_id:
+        raise ValueError("Project ID is not set")
+
+    # Prepare drivers
+    facts_drivers = []
+
+    # Prepare models
+    models = {}
+    models_map = ua_utils.cfg_load_section_map(CONF.config_file, "models")
+    for kind, model_path in models_map.items():
+        core_model = ua_utils.cfg_load_class(model_path)
+        models[kind] = core_model
+        LOG.info("Loaded model: %s by %s", core_model, model_path)
+
+    # Prepare filters
+    filters = load_filters(CONF[DOMAIN].project_id)
+
+    # Prepare model specs
+    specs = []
+    for kind, model in models.items():
+        spec = db_back.ModelSpec(
+            kind=kind,
+            model=model,
+            filters=filters[kind],
+        )
+        specs.append(spec)
+
+    db_core_driver = ua_core_drivers.DatabaseCapabilityDriver(
+        model_specs=specs,
+        target_fields_storage_path=CONF[DOMAIN].target_fields_path,
+    )
+
+    caps_drivers = [
+        db_core_driver,
+    ]
+
+    # Prepare orch client
+    if CONF[DOMAIN].orch_client == "http":
+        http_client = bazooka.Client(default_timeout=20)
+        orch_client = orch_http.HttpOrchClient(
+            orch_endpoint=CONF[DOMAIN].orch_endpoint,
+            status_endpoint=CONF[DOMAIN].status_endpoint,
+            http_client=http_client,
+        )
+    elif CONF[DOMAIN].orch_client == "db":
+        orch_client = orch_db.DatabaseOrchClient()
+    else:
+        raise ValueError(f"Unknown orch client: {CONF[DOMAIN].orch_client}")
+
+    service = agent.UniversalAgentService(
+        agent_uuid=agent_uuid,
+        orch_client=orch_client,
+        caps_drivers=caps_drivers,
+        facts_drivers=facts_drivers,
+        payload_path=CONF[DOMAIN].payload_path,
+        iter_min_period=3,
+    )
+
+    service.start()
+
+    log.info("Bye!!!")
+
+
+if __name__ == "__main__":
+    main()

--- a/gcl_sdk/agents/universal/drivers/core.py
+++ b/gcl_sdk/agents/universal/drivers/core.py
@@ -17,11 +17,9 @@ from __future__ import annotations
 
 import os
 import logging
-import uuid as sys_uuid
 import typing as tp
 
 import bazooka
-from restalchemy.storage import base as ra_storage
 
 from gcl_sdk.clients.http import base
 from gcl_sdk.agents.universal.drivers import direct
@@ -89,16 +87,11 @@ class DatabaseCapabilityDriver(direct.DirectAgentDriver):
 
     def __init__(
         self,
-        models: tp.Collection[
-            tuple[tp.Type[ra_storage.AbstractStorableMixin], str]
-        ],
-        project_id: sys_uuid.UUID,
+        model_specs: tp.Collection[db_back.ModelSpec],
         target_fields_storage_path: str,
     ):
 
-        model_specs = db_back.ModelSpec.from_collection(models, project_id)
         client = db_back.DatabaseBackendClient(model_specs)
-
         storage = fs.TargetFieldsFileStorage(target_fields_storage_path)
 
         self._kinds = {m.kind for m in model_specs}

--- a/gcl_sdk/agents/universal/utils.py
+++ b/gcl_sdk/agents/universal/utils.py
@@ -16,10 +16,13 @@
 from __future__ import annotations
 
 import os
+import sys
+import importlib
 import json
 import xxhash
 import typing as tp
 import uuid as sys_uuid
+import configparser
 
 from gcl_sdk.agents.universal import constants as c
 
@@ -56,3 +59,59 @@ def calculate_hash(
         )
     )
     return m.hexdigest()
+
+
+def cfg_load_class(model_path: str) -> tp.Type:
+    """Load class from config file.
+
+    Model path format: <module>:<class>
+    Example: gcl_sdk.infra.dm.models:Node
+    """
+    if ":" not in model_path:
+        raise ValueError(f"Invalid model path: {model_path}")
+
+    module_path, class_name = model_path.split(":", 1)
+
+    # Import the module if it's not already loaded
+    if module_path not in sys.modules:
+        try:
+            module = importlib.import_module(module_path)
+        except ImportError:
+            raise ValueError(f"Module {module_path} not found")
+    else:
+        module = sys.modules[module_path]
+
+    try:
+        class_model = getattr(module, class_name)
+    except AttributeError:
+        raise ValueError(
+            f"Class {class_name} not found in module {module_path}"
+        )
+
+    return class_model
+
+
+def cfg_load_section_map(config_file: str, section: str) -> dict[str, str]:
+    """Load section map from config file
+
+    Example:
+    [section]
+    option1 = value1
+    option2 = value2
+
+    Returns: {"option1": "value1", "option2": "value2"}
+    """
+    params = {}
+    parser = configparser.ConfigParser()
+    parser.read(config_file)
+
+    if not parser.has_section(section):
+        return params
+
+    for option in parser.options(section):
+        if option in parser.defaults():
+            continue
+
+        params[option] = parser.get(section, option)
+
+    return params

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ packages =
 [entry_points]
 console_scripts =
     genesis-universal-agent = gcl_sdk.agents.universal.cmd.universal_agent:main
+    genesis-universal-agent-db-back = gcl_sdk.agents.universal.cmd.universal_agent_db_back:main
     genesis-universal-scheduler = gcl_sdk.agents.universal.cmd.scheduler:main
 
 gcl_sdk_event_payloads =


### PR DESCRIPTION
Wrapper around UA based on DatabaseCapabilityDriver
    
Another wrapper around the universal agent. The key feature of this service wrapper is focusing on DatabaseCapabilityDriver and tools to simplify configuration pair UA + DatabaseCapabilityDriver. Most core agents in the final services are going to use this service as a base.
    
The key changes:
- Added a new command `genesis-universal-agent-db-back` to run the UA.
- A couple of helper functions.
- DatabaseCapabilityDriver has been improved to accept any filters and
  not only project_id.