### PR TITLE
Integration with TS storage for backend clients

### DIFF
--- a/gcl_sdk/agents/universal/storage/base.py
+++ b/gcl_sdk/agents/universal/storage/base.py
@@ -72,3 +72,7 @@ class AbstractTargetFieldsStorage(abc.ABC):
     @abc.abstractmethod
     def persist(self) -> None:
         """Persist the storage."""
+
+    @abc.abstractmethod
+    def storage(self) -> tp.Any:
+        """Return the raw storage."""

--- a/gcl_sdk/agents/universal/storage/fs.py
+++ b/gcl_sdk/agents/universal/storage/fs.py
@@ -93,3 +93,7 @@ class TargetFieldsFileStorage(base.AbstractTargetFieldsStorage):
     def persist(self) -> None:
         """Persist the storage."""
         self._storage.persist()
+
+    def storage(self) -> dict[str, dict[str, list[str]]]:
+        """Return the raw storage."""
+        return self._storage

--- a/gcl_sdk/tests/unit/agents/drivers/test_db_backend.py
+++ b/gcl_sdk/tests/unit/agents/drivers/test_db_backend.py
@@ -1,0 +1,286 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import uuid as sys_uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+from gcl_sdk.agents.universal.clients.backend.db import (
+    DatabaseBackendClient,
+    ModelSpec,
+)
+from gcl_sdk.agents.universal.clients.backend import exceptions as client_exc
+from gcl_sdk.agents.universal.dm import models
+from gcl_sdk.agents.universal.storage import base as storage_base
+from restalchemy.dm import filters as dm_filters
+from restalchemy.storage import exceptions as ra_exc
+
+
+def _make_resource(
+    kind: str, uuid: sys_uuid.UUID | None = None, value: dict | None = None
+) -> models.Resource:
+    uuid = uuid or sys_uuid.uuid4()
+    value = value or {"uuid": str(uuid), "a": 1, "b": 2}
+    return models.Resource.from_value(value, kind, frozenset(value.keys()))
+
+
+class TestDatabaseBackendClient:
+    def test_get_success_uses_filters_and_returns_obj(self):
+        # Arrange
+        kind = "config"
+        resource = _make_resource(kind)
+
+        # Model and manager mocks
+        obj = MagicMock(name="ModelInstance")
+        manager = MagicMock()
+        manager.get_one.return_value = obj
+
+        model = MagicMock()
+        model.objects = manager
+
+        # ModelSpec with extra filter
+        ms = ModelSpec(
+            model=model, kind=kind, filters={"project": dm_filters.EQ("p1")}
+        )
+
+        storage = MagicMock()
+        client = DatabaseBackendClient(model_specs=[ms], tf_storage=storage)
+
+        # Act
+        actual = client.get(resource)
+
+        # Assert
+        assert actual is obj
+        # ensure filters include uuid and extra filter
+        args, kwargs = manager.get_one.call_args
+        assert "filters" in kwargs
+        flt = kwargs["filters"]
+        assert set(flt.keys()) == {"uuid", "project"}
+        assert isinstance(flt["uuid"], dm_filters.EQ)
+        assert flt["uuid"].value == str(resource.uuid)
+        assert isinstance(flt["project"], dm_filters.EQ)
+        assert flt["project"].value == "p1"
+
+    def test_get_maps_not_found(self):
+        kind = "config"
+        resource = _make_resource(kind)
+
+        manager = MagicMock()
+        manager.get_one.side_effect = ra_exc.RecordNotFound(
+            model="Model", filters={"uuid": str(resource.uuid)}
+        )
+
+        model = MagicMock()
+        model.objects = manager
+        ms = ModelSpec(model=model, kind=kind, filters={})
+
+        client = DatabaseBackendClient(
+            model_specs=[ms], tf_storage=MagicMock()
+        )
+
+        with pytest.raises(client_exc.ResourceNotFound):
+            client.get(resource)
+
+    def test_list_returns_empty_if_no_filters_and_no_target_fields(self):
+        kind = "config"
+        # ModelSpec without predefined filters -> uses storage
+        ms = ModelSpec(model=MagicMock(), kind=kind, filters=None)
+
+        storage = MagicMock()
+        storage.storage.return_value = {kind: {}}  # empty for this kind
+
+        client = DatabaseBackendClient(model_specs=[ms], tf_storage=storage)
+
+        res = client.list(kind)
+
+        assert res == []
+        # get_all should not be called when filters are empty
+        assert not ms.model.objects.get_all.called
+
+    def test_list_uses_storage_target_fields_to_build_in_filter(self):
+        kind = "config"
+
+        manager = MagicMock()
+        expected_list = [MagicMock(name="Model1"), MagicMock(name="Model2")]
+        manager.get_all.return_value = expected_list
+
+        model = MagicMock()
+        model.objects = manager
+
+        ms = ModelSpec(model=model, kind=kind, filters=None)
+
+        storage = MagicMock()
+        storage.storage.return_value = {
+            kind: {
+                "uuid1": ["a", "b"],
+                "uuid2": ["a"],
+            }
+        }
+
+        client = DatabaseBackendClient(model_specs=[ms], tf_storage=storage)
+
+        res = client.list(kind)
+
+        assert res == expected_list
+        args, kwargs = manager.get_all.call_args
+        assert "filters" in kwargs and "uuid" in kwargs["filters"]
+        uuid_filter = kwargs["filters"]["uuid"]
+        assert isinstance(uuid_filter, dm_filters.In)
+        # should include both keys from storage
+        assert set(uuid_filter.value) == {"uuid1", "uuid2"}
+
+    def test_create_injects_filter_fields_and_uses_restore_when_missing(self):
+        kind = "config"
+        uid = str(sys_uuid.uuid4())
+        resource = _make_resource(kind, value={"uuid": uid, "a": 10})
+
+        manager = MagicMock()
+        manager.get_one_or_none.return_value = None  # not exists
+
+        model_instance = MagicMock()
+        model = MagicMock()
+        model.objects = manager
+        model.restore_from_simple_view.return_value = model_instance
+
+        # Filters should be injected into value if missing
+        ms = ModelSpec(
+            model=model,
+            kind=kind,
+            filters={"project": dm_filters.EQ("p1")},
+            inject_filter_fields=True,
+        )
+
+        storage = MagicMock()
+        client = DatabaseBackendClient(model_specs=[ms], tf_storage=storage)
+
+        actual = client.create(resource)
+
+        # Should have called restore_from_simple_view with injected field
+        kwargs = model.restore_from_simple_view.call_args.kwargs
+        assert kwargs["uuid"] == uid
+        assert kwargs["a"] == 10
+        assert kwargs["project"] == "p1"
+
+        # and then insert called
+        model_instance.insert.assert_called_once()
+        assert actual is model_instance
+
+    def test_create_raises_already_exists(self):
+        kind = "config"
+        resource = _make_resource(kind)
+
+        manager = MagicMock()
+        manager.get_one_or_none.return_value = MagicMock()
+
+        model = MagicMock()
+        model.objects = manager
+
+        ms = ModelSpec(model=model, kind=kind, filters={})
+
+        client = DatabaseBackendClient(
+            model_specs=[ms], tf_storage=MagicMock()
+        )
+
+        with pytest.raises(client_exc.ResourceAlreadyExists):
+            client.create(resource)
+
+    def test_update_not_found_when_missing(self):
+        kind = "config"
+        resource = _make_resource(kind)
+
+        manager = MagicMock()
+        manager.get_one_or_none.return_value = None
+
+        model = MagicMock()
+        model.objects = manager
+
+        ms = ModelSpec(model=model, kind=kind, filters={})
+        client = DatabaseBackendClient(
+            model_specs=[ms], tf_storage=MagicMock()
+        )
+
+        with pytest.raises(client_exc.ResourceNotFound):
+            client.update(resource)
+
+    def test_update_updates_only_non_read_only_and_calls_update(self):
+        kind = "config"
+        # new value wants to change both a and b
+        uid = str(sys_uuid.uuid4())
+        resource = _make_resource(kind, value={"uuid": uid, "a": 10, "b": 20})
+
+        # existing object with properties and current values
+        prop_a = MagicMock()
+        prop_a.is_read_only.return_value = True
+        prop_b = MagicMock()
+        prop_b.is_read_only.return_value = False
+
+        existing_obj = MagicMock()
+        existing_obj.properties = {"a": prop_a, "b": prop_b}
+        existing_obj.a = 1
+        existing_obj.b = 2
+
+        manager = MagicMock()
+        manager.get_one_or_none.return_value = existing_obj
+
+        # model.from_ua_resource returns an object with desired values
+        updated_obj = MagicMock()
+        updated_obj.a = 10
+        updated_obj.b = 20
+
+        model = MagicMock()
+        model.objects = manager
+        model.from_ua_resource.return_value = updated_obj
+
+        ms = ModelSpec(model=model, kind=kind, filters={})
+        client = DatabaseBackendClient(
+            model_specs=[ms], tf_storage=MagicMock()
+        )
+
+        actual = client.update(resource)
+
+        # a is read-only -> unchanged
+        assert existing_obj.a == 1
+        # b is writable -> updated
+        assert existing_obj.b == 20
+        existing_obj.update.assert_called_once()
+        assert actual is existing_obj
+
+    def test_delete_deletes_when_found_and_noop_when_missing(self):
+        kind = "config"
+        resource = _make_resource(kind)
+
+        # Case 1: found and deleted
+        obj = MagicMock()
+        manager = MagicMock()
+        manager.get_one.return_value = obj
+
+        model = MagicMock()
+        model.objects = manager
+        ms = ModelSpec(model=model, kind=kind, filters={})
+
+        client = DatabaseBackendClient(
+            model_specs=[ms], tf_storage=MagicMock()
+        )
+        client.delete(resource)
+        obj.delete.assert_called_once()
+
+        # Case 2: not found -> should not raise
+        manager.get_one.side_effect = ra_exc.RecordNotFound(
+            model="Model", filters={"uuid": str(resource.uuid)}
+        )
+        client.delete(resource)
+        # No exception raised

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,3 +37,4 @@ gcl_sdk_universal_agent =
     RenderAgentDriver = gcl_sdk.agents.universal.drivers.render:RenderAgentDriver
     SSHKeyCapabilityDriver = gcl_sdk.agents.universal.drivers.ssh_key:SSHKeyCapabilityDriver
     CoreCapabilityDriver = gcl_sdk.agents.universal.drivers.core:CoreCapabilityDriver
+    RestCoreCapabilityDriver = gcl_sdk.agents.universal.drivers.core:RestCoreCapabilityDriver


### PR DESCRIPTION
The backend clients `DatabaseBackendClient` and `GCRestApiBackendClient` were integrated with `target fields storage` to have an ability for flexble filtering when there is no a specific field like `project_id`. In this case they use collection of UUIDs from the `target fields storage` to detect which entities belongs them and which not.