### PR TITLE
Introduce SchedulableToAgentMixin for simple scheduling logic

### DIFF
--- a/gcl_sdk/agents/universal/dm/models.py
+++ b/gcl_sdk/agents/universal/dm/models.py
@@ -825,6 +825,57 @@ class OutdatedMasterFullHashResource(
     )
 
 
+class SchedulableToAgentMixin:
+    """A helpful mixin to schedule resources to the UA agent for simple cases.
+
+    Actually scheduling is a responsibility of a separated scheduler
+    service but in some simple cases an UA agent is known right after
+    a resource is created. The mixin provides a way to schedule the
+    resource if the UA agent is able to get or calculate from the
+    internal data.
+    """
+
+    def schedule_to_ua_agent(self, **kwargs) -> sys_uuid.UUID | None:
+        """Schedule the resource to the UA agent.
+
+        The method returns the UA agent UUID.
+
+        The UA agent UUID is the same as the resource UUID
+        for the simplest case when the resource is scheduled
+        to the UA agent. It's convenient if relation between
+        the resource and the UA agent is one-to-one.
+        """
+        return self.uuid
+
+
+class SchedulableToAgentFromNodeMixin(SchedulableToAgentMixin):
+
+    def schedule_to_ua_agent(self, **kwargs) -> sys_uuid.UUID | None:
+        """Schedule the resource to the UA agent.
+
+        The method returns the node UUID that is equal to the
+        agent UUID.
+        """
+        return self.node
+
+
+class SchedulableToAgentFromAgentUUIDMixin(
+    SchedulableToAgentMixin,
+    models.Model,
+):
+
+    agent_uuid = properties.property(
+        types.AllowNone(types.UUID()), default=None
+    )
+
+    def schedule_to_ua_agent(self, **kwargs) -> sys_uuid.UUID | None:
+        """Schedule the resource to the UA agent.
+
+        The method returns the agent UUID.
+        """
+        return self.agent_uuid
+
+
 class KindAwareMixin:
     """A helpful mixin to get the resource kind."""
 


### PR DESCRIPTION
Introduce scheduling logic in the universal builder for simple cases if the agent UUID is known right after resource creation.

New `SchedulableToAgentMixin` was added as an interface for resources that would like to use this new simple scheduling logic. Also some most common implementations for `SchedulableToAgentMixin` were added.