### PR TITLE
Ability to invalidate DP object

### DIFF
--- a/gcl_sdk/agents/universal/drivers/exceptions.py
+++ b/gcl_sdk/agents/universal/drivers/exceptions.py
@@ -13,6 +13,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+
+import typing as tp
+
 from gcl_sdk.common import exceptions
 from gcl_sdk.agents.universal.dm import models
 
@@ -29,3 +32,14 @@ class ResourceAlreadyExists(AgentDriverException):
 class ResourceNotFound(AgentDriverException):
     __template__ = "The resource not found: {resource}"
     resource: models.Resource
+
+
+class InvalidDataPlaneObjectError(AgentDriverException):
+    """The data plane object is invalid exception.
+
+    The exception is thrown when the data plane object is invalid
+    and driver expects it will be called to recreate the DP object.
+    """
+
+    __template__ = "The data plane object is invalid: {obj}"
+    obj: tp.Any

--- a/gcl_sdk/agents/universal/drivers/meta.py
+++ b/gcl_sdk/agents/universal/drivers/meta.py
@@ -209,6 +209,16 @@ class MetaFileStorageAgentDriver(base.AbstractCapabilityDriver):
             try:
                 obj.restore_from_dp()
                 dp_objects.append(obj)
+            except driver_exc.InvalidDataPlaneObjectError:
+                # TODO(akremenetsky): Seems some destructive actions happened
+                # on the data plane. It's not clear what happened but the
+                # object is invalid. We need to save this information in the
+                # audit journal.
+
+                LOG.error(
+                    "Invalid data plane object: %s. It will be recreated.",
+                    obj.uuid,
+                )
             except driver_exc.ResourceNotFound:
                 LOG.error("Resource %s not found on the data plane", obj.uuid)
 
@@ -222,6 +232,16 @@ class MetaFileStorageAgentDriver(base.AbstractCapabilityDriver):
         # Check the resource does not exist
         try:
             self.get(resource)
+        except driver_exc.InvalidDataPlaneObjectError:
+            # TODO(akremenetsky): Seems some destructive actions happened
+            # on the data plane. It's not clear what happened but the
+            # object is invalid. We need to save this information in the
+            # audit journal.
+
+            LOG.error(
+                "Invalid data plane object: %s. It will be recreated.",
+                resource.uuid,
+            )
         except driver_exc.ResourceNotFound:
             # Desirable behavior, the resource should not exist
             pass


### PR DESCRIPTION
Added interface via raising exception `InvalidDataPlaneObjectError` to say the driver the object is invalid and it should be recreated.

Added implementation for this logic in `MetaFileStorageAgentDriver`.

Closes #41