### PR TITLE
LB: introduce local_dir_download action

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ gcl_iam>=0.15.0,<2.0.0  # Apache-2.0
 gcl_looper>=1.0.1,<2.0.0  # Apache-2.0
 bjoern>=3.2.2  # BSD License (BSD-3-Clause)
 izulu>=0.50.0,<1.0.0  # MIT License
+renameat2>=0.4.4,<1.0.0  # MIT License
 xxhash>=3.5.0,<4.0.0 # BSD 2-Clause License


### PR DESCRIPTION
It allows to download tar.gz/tar.zst archive,
unpack it and serve static from LB itself.

In addition, url change is an atomic operation:
while new archive is not extracted and ready to use,
old data is served.