### PR TITLE
fix: self-heal IAM users missing from data plane

### DIFF
--- a/gcl_sdk/agents/universal/clients/backend/core.py
+++ b/gcl_sdk/agents/universal/clients/backend/core.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import logging
 import typing as tp
 import uuid as sys_uuid
 
@@ -27,6 +28,8 @@ from gcl_sdk.clients.http import base as http
 from gcl_sdk.agents.universal.clients.backend import rest
 from gcl_sdk.agents.universal.clients.backend import exceptions
 from gcl_sdk.agents.universal.storage import base as storage_base
+
+LOG = logging.getLogger(__name__)
 
 
 class ResourceProjectMismatch(exceptions.BackendClientException):
@@ -145,17 +148,25 @@ class GCUsersRestApiBackendClient(rest.RestApiBackendClient):
         resources = {
             str(r.uuid): r
             for r in models.Resource.objects.get_all(
-                filters={"uuid": dm_filters.In(uuids)}
+                filters={
+                    "uuid": dm_filters.In(uuids),
+                    "kind": dm_filters.EQ(self._user_kind),
+                }
             )
         }
 
         # Enrich users with additional data
+        # Skip users not found in data plane - they may have been deleted
+        enriched_users = []
         for user in users:
             if user["uuid"] not in resources:
-                raise ValueError(f"Resource with UUID {user['uuid']} not found")
-            user["password"] = resources[user["uuid"]].value["password"]
+                LOG.warning("User %s not found in data plane, skipping", user["uuid"])
+                continue
+            res = resources[user["uuid"]]
+            user["password"] = res.value.get("password", "")
+            enriched_users.append(user)
 
-        return users
+        return enriched_users
 
     def get(self, resource: models.Resource) -> dict[str, tp.Any]:
         """Get the resource value in dictionary format."""
@@ -166,9 +177,18 @@ class GCUsersRestApiBackendClient(rest.RestApiBackendClient):
         except bazooka_exc.NotFoundError:
             raise exceptions.ResourceNotFound(resource=resource)
 
-        result = self._enrich_users([result])[0]
-
-        return result
+        enriched = self._enrich_users([result])
+        if not enriched:
+            # User exists in IAM but has no data plane record (e.g. after partial
+            # failure or manual IAM creation). Use the target resource's password
+            # so the resource can be collected and the DB record self-heals.
+            LOG.warning(
+                "User %s has no data plane record, using target password as fallback",
+                resource.uuid,
+            )
+            result["password"] = resource.value.get("password", "")
+            return result
+        return enriched[0]
 
     def create(self, resource: models.Resource) -> dict[str, tp.Any]:
         """Creates the resource. Returns the created resource."""

--- a/gcl_sdk/tests/unit/agents/drivers/test_user_capability_driver.py
+++ b/gcl_sdk/tests/unit/agents/drivers/test_user_capability_driver.py
@@ -162,15 +162,17 @@ class TestGCUsersRestApiBackendClientEnrichUsers:
 
         assert enriched[0]["password"] == "s3cr3t"
 
-    def test_raises_when_db_resource_not_found(self):
+    def test_skips_user_when_db_resource_not_found(self):
         uuid = sys_uuid.uuid4()
         client = _make_client()
         users = [{"uuid": str(uuid), "name": "ghost"}]
 
         with patch(_CORE_MODELS) as mr:
             mr.objects.get_all.return_value = []
-            with pytest.raises(ValueError, match=str(uuid)):
-                client._enrich_users(users)
+            enriched = client._enrich_users(users)
+
+        # User should be skipped, not raise an error
+        assert enriched == []
 
 
 class TestGCUsersRestApiBackendClientGet:
@@ -199,6 +201,21 @@ class TestGCUsersRestApiBackendClientGet:
 
         with pytest.raises(client_exc.ResourceNotFound):
             client.get(res)
+
+    def test_get_falls_back_to_target_password_when_user_not_in_data_plane(self):
+        uuid = sys_uuid.uuid4()
+        res = _make_resource(uuid=uuid)
+
+        client = _make_client()
+        client._client.get.return_value = {"uuid": str(uuid), "name": "alice"}
+
+        with patch(_CORE_MODELS) as mr:
+            mr.objects.get_all.return_value = []
+            result = client.get(res)
+
+        # Should not raise - falls back to target resource password
+        assert result["password"] == "s3cr3t"
+        assert result["uuid"] == str(uuid)
 
 
 class TestGCUsersRestApiBackendClientCreate:
@@ -304,6 +321,27 @@ class TestGCUsersRestApiBackendClientUpdate:
 
         # resource.value must be restored after exception (same keys as before update)
         assert res.value == value_before
+
+    def test_update_falls_back_to_target_password_when_user_not_in_data_plane(self):
+        uuid = sys_uuid.uuid4()
+        value = {
+            "uuid": str(uuid),
+            "name": "eve",
+            "password": "newpass",
+            "status": "ACTIVE",
+        }
+        res = _make_resource(uuid=uuid, value=value)
+
+        client = _make_client()
+        client._client.get.return_value = {"uuid": str(uuid), "name": "eve"}
+        client._client.update.return_value = {"uuid": str(uuid), "name": "eve"}
+
+        with patch(_CORE_MODELS) as mr:
+            mr.objects.get_all.return_value = []
+            result = client.update(res)
+
+        # Should not raise - falls back to target resource password
+        assert result["password"] == "newpass"
 
 
 class TestGCUsersRestApiBackendClientList:


### PR DESCRIPTION
When a user exists in IAM but has no ua_actual_resources record, get() now falls back to the target resource's password instead of raising ResourceNotFound. This breaks the infinite create→409→get→ ResourceNotFound cycle, allowing the resource to be collected and the DB record to be written on the next facts actualization.