### PR TITLE
Add node verification on agent registration

### DIFF
--- a/gcl_sdk/agents/universal/clients/http/status.py
+++ b/gcl_sdk/agents/universal/clients/http/status.py
@@ -20,12 +20,35 @@ import typing as tp
 import bazooka
 
 from gcl_sdk.agents.universal.dm import models
+from gcl_sdk.agents.universal.status_api.dm import models as status_models
 from gcl_sdk.clients.http import base
 
 
 class UniversalAgentsClient(base.StaticCollectionBaseModelClient):
     __collection_path__ = "/v1/agents/"
     __model__ = models.UniversalAgent
+
+
+class NodeVerifiersClient(base.StaticCollectionBaseModelClient):
+    __collection_path__ = "/v1/node_verifiers/"
+    __model__ = status_models.NodeVerifier
+
+    def verify(self, uuid: sys_uuid.UUID) -> bool:
+        """Verify that a node encryption key exists.
+
+        Args:
+            uuid: The UUID of the node to verify.
+
+        Returns:
+            True if the node encryption key exists, False otherwise.
+        """
+        result = self.do_action("verify", uuid)
+        return result.get("valid", False)
+
+
+class NodesClient(base.StaticCollectionBaseModelClient):
+    __collection_path__ = "/v1/nodes/"
+    __model__ = models.NodeEncryptionKey
 
 
 class ResourcesClient(base.CollectionBaseModelClient):
@@ -113,10 +136,17 @@ class StatusAPI:
         self._agents_client = UniversalAgentsClient(
             base_url, http_client=http_client, encryptor=encryptor
         )
+        self._node_verifiers_client = NodeVerifiersClient(
+            base_url, http_client=http_client, encryptor=encryptor
+        )
 
     @property
     def agents(self) -> UniversalAgentsClient:
         return self._agents_client
+
+    @property
+    def node_verifiers(self) -> NodeVerifiersClient:
+        return self._node_verifiers_client
 
     @functools.lru_cache
     def resources(self, kind: str) -> ResourcesClient:

--- a/gcl_sdk/agents/universal/clients/orch/base.py
+++ b/gcl_sdk/agents/universal/clients/orch/base.py
@@ -30,7 +30,10 @@ class AbstractOrchClient(abc.ABC):
 
     @abc.abstractmethod
     def agents_create(
-        self, agent: models.UniversalAgent, **kwargs: tp.Any
+        self,
+        agent: models.UniversalAgent,
+        check_node_exists: bool = False,
+        **kwargs: tp.Any,
     ) -> models.UniversalAgent:
         """Create an instance of Universal agent."""
 

--- a/gcl_sdk/agents/universal/clients/orch/db.py
+++ b/gcl_sdk/agents/universal/clients/orch/db.py
@@ -25,6 +25,7 @@ from restalchemy.dm import filters as dm_filters
 from restalchemy.storage import exceptions as ra_exc
 
 from gcl_sdk.agents.universal.dm import models
+from gcl_sdk.agents.universal.status_api.dm import models as status_models
 from gcl_sdk.agents.universal.clients.orch import base
 from gcl_sdk.agents.universal.clients.orch import exceptions
 
@@ -45,14 +46,40 @@ class DatabaseOrchClient(base.AbstractOrchClient):
             with contexts.Context().session_manager() as session:
                 yield session
 
+    def _verify_node_exists(
+        self, agent: models.UniversalAgent, session: tp.Any
+    ) -> None:
+        """Verify that the agent's node encryption key exists.
+
+        Args:
+            agent: The UniversalAgent to verify.
+            session: The database session.
+
+        Raises:
+            exceptions.NodeNotFound: If the node encryption key doesn't exist.
+        """
+        if agent.node is None:
+            raise exceptions.NodeNotFound(uuid=None)
+
+        try:
+            status_models.NodeVerifier.objects.get_one(
+                filters={"uuid": dm_filters.EQ(str(agent.node))},
+                session=session,
+            )
+        except ra_exc.RecordNotFound:
+            raise exceptions.NodeNotFound(uuid=agent.node)
+
     def agents_create(
         self,
         agent: models.UniversalAgent,
+        check_node_exists: bool = False,
         session: tp.Any = None,
     ) -> models.UniversalAgent:
         """Create an instance of Universal agent."""
         try:
             with self._session_context(session=session) as s:
+                if check_node_exists:
+                    self._verify_node_exists(agent, session=s)
                 return agent.insert(session=s)
         except ra_exc.ConflictRecords:
             raise exceptions.AgentAlreadyExists(uuid=agent.uuid)

--- a/gcl_sdk/agents/universal/clients/orch/exceptions.py
+++ b/gcl_sdk/agents/universal/clients/orch/exceptions.py
@@ -41,3 +41,8 @@ class ResourceAlreadyExists(OrchClientException):
 class ResourceNotFound(OrchClientException):
     __template__ = "The resource not found: {uuid}"
     uuid: sys_uuid.UUID
+
+
+class NodeNotFound(OrchClientException):
+    __template__ = "The node not found: {uuid}"
+    uuid: sys_uuid.UUID | None

--- a/gcl_sdk/agents/universal/clients/orch/http.py
+++ b/gcl_sdk/agents/universal/clients/orch/http.py
@@ -58,10 +58,33 @@ class HttpOrchClient(base.AbstractOrchClient):
             encryptor=encryptor,
         )
 
+    def _verify_node_exists(self, agent: models.UniversalAgent) -> None:
+        """Verify that the agent's node encryption key exists.
+
+        Args:
+            agent: The UniversalAgent to verify.
+
+        Raises:
+            exceptions.NodeNotFound: If the node encryption key doesn't exist.
+        """
+        if agent.node is None:
+            raise exceptions.NodeNotFound(uuid=None)
+
+        try:
+            self._status_api.node_verifiers.verify(agent.node)
+        except baz_exc.NotFoundError:
+            raise exceptions.NodeNotFound(uuid=agent.node)
+
     def agents_create(
-        self, agent: models.UniversalAgent, **kwargs: tp.Any
+        self,
+        agent: models.UniversalAgent,
+        check_node_exists: bool = False,
+        **kwargs: tp.Any,
     ) -> models.UniversalAgent:
         """Create an instance of Universal agent."""
+        if check_node_exists:
+            self._verify_node_exists(agent)
+
         try:
             agent = self._status_api.agents.create(agent)
             LOG.info("Agent registered: %s", agent.uuid)

--- a/gcl_sdk/agents/universal/cmd/universal_agent.py
+++ b/gcl_sdk/agents/universal/cmd/universal_agent.py
@@ -86,6 +86,11 @@ core_agent_opts = [
         default=c.PRIVATE_KEY_PATH,
         help="Path to the private key file.",
     ),
+    cfg.BoolOpt(
+        "verify_node_on_register",
+        default=True,
+        help="Verify that the node encryption key exists before registering the agent.",
+    ),
 ]
 
 CONF = cfg.CONF
@@ -211,6 +216,7 @@ def main():
         facts_drivers=facts_drivers,
         payload_path=CONF[DOMAIN].payload_path,
         iter_min_period=3,
+        verify_node_on_register=CONF[DOMAIN].verify_node_on_register,
     )
 
     service.start()

--- a/gcl_sdk/agents/universal/cmd/universal_agent_db_back.py
+++ b/gcl_sdk/agents/universal/cmd/universal_agent_db_back.py
@@ -90,6 +90,11 @@ core_agent_opts = [
         default=c.PRIVATE_KEY_PATH,
         help="Path to the private key file.",
     ),
+    cfg.BoolOpt(
+        "verify_node_on_register",
+        default=True,
+        help="Verify that the node encryption key exists before registering the agent.",
+    ),
 ]
 
 CONF = cfg.CONF
@@ -212,6 +217,7 @@ def main():
         facts_drivers=facts_drivers,
         payload_path=CONF[DOMAIN].payload_path,
         iter_min_period=3,
+        verify_node_on_register=CONF[DOMAIN].verify_node_on_register,
     )
 
     service.start()

--- a/gcl_sdk/agents/universal/services/agent.py
+++ b/gcl_sdk/agents/universal/services/agent.py
@@ -44,6 +44,7 @@ class UniversalAgentService(looper_basic.BasicService):
         iter_min_period: float = 3,
         iter_pause: float = 0.1,
         system_uuid: sys_uuid.UUID | None = None,
+        verify_node_on_register: bool = True,
     ):
         super().__init__(iter_min_period, iter_pause)
         self._orch_client = orch_client
@@ -52,6 +53,7 @@ class UniversalAgentService(looper_basic.BasicService):
         self._system_uuid = system_uuid
         self._caps_drivers = caps_drivers
         self._facts_drivers = facts_drivers
+        self._verify_node_on_register = verify_node_on_register
 
     def _register_agent(self) -> None:
         capabilities = itertools.chain.from_iterable(
@@ -67,13 +69,19 @@ class UniversalAgentService(looper_basic.BasicService):
             system_uuid=self._system_uuid,
         )
         try:
-            self._orch_client.agents_create(agent)
+            self._orch_client.agents_create(
+                agent, check_node_exists=self._verify_node_on_register
+            )
             LOG.info("Agent registered: %s", agent.uuid)
         except orch_exc.AgentAlreadyExists:
             LOG.warning("Agent already registered: %s", agent.uuid)
 
             # Update the agent capabilities and facts if they were changed
             self._orch_client.agents_update(agent)
+        except orch_exc.NodeNotFound:
+            LOG.warning(
+                "Node verification failed, cannot register agent %s", agent.uuid
+            )
 
     def _create_resource(
         self,

--- a/gcl_sdk/agents/universal/status_api/controllers.py
+++ b/gcl_sdk/agents/universal/status_api/controllers.py
@@ -70,6 +70,32 @@ class UniversalAgentsController(sdk_controllers.BaseSdkResourceController):
     )
 
 
+class NodeVerifierController(sdk_controllers.BaseSdkResourceController):
+    """Controller for /v1/node_verifiers/ endpoint"""
+
+    __resource__ = resources.ResourceByRAModel(
+        model_class=models.NodeVerifier,
+        process_filters=True,
+        convert_underscore=False,
+    )
+
+    @actions.get
+    def verify(self, resource: models.NodeVerifier):
+        """Verify that a node encryption key exists.
+
+        The action automatically loads the resource. If the key doesn't
+        exist, the framework raises an error. Successful execution confirms
+        the key is valid and present in the database.
+
+        Args:
+            resource: The NodeVerifier model instance to verify.
+
+        Returns:
+            dict: {"valid": True} if the key exists.
+        """
+        return {"valid": True}
+
+
 class NodesController(sdk_controllers.BaseSdkResourceController):
     """Controller for /v1/nodes/ endpoint"""
 

--- a/gcl_sdk/agents/universal/status_api/dm/models.py
+++ b/gcl_sdk/agents/universal/status_api/dm/models.py
@@ -22,6 +22,7 @@ from restalchemy.dm import types
 from restalchemy.dm import models as ra_models
 from restalchemy.dm import relationships
 from restalchemy.storage.sql import engines
+from restalchemy.storage.sql import orm
 from restalchemy.storage import base as base_storage
 from restalchemy.common import utils as ra_utils
 from restalchemy.storage import exceptions as storage_exc
@@ -97,3 +98,13 @@ class UniversalAgent(models.UniversalAgent):
 # launch functional tests
 class NodeEncryptionKey(models.NodeEncryptionKey):
     pass
+
+
+class NodeVerifier(ra_models.ModelWithUUID, orm.SQLStorableMixin):
+    """View model for verifying node encryption key existence.
+
+    This is a read-only view on ua_node_encryption_keys table
+    containing only the uuid column for node verification purposes.
+    """
+
+    __tablename__ = "ua_node_verifiers_view"

--- a/gcl_sdk/agents/universal/status_api/routes.py
+++ b/gcl_sdk/agents/universal/status_api/routes.py
@@ -60,6 +60,12 @@ class RefreshSecretAction(routes.Action):
     __controller__ = controllers.NodesController
 
 
+class NodeVerifierVerifyAction(routes.Action):
+    """Handler for /v1/node_verifiers/<uuid>/actions/verify endpoint"""
+
+    __controller__ = controllers.NodeVerifierController
+
+
 class NodesRoute(routes.Route):
     """Handler for /v1/nodes/ endpoint"""
 
@@ -67,3 +73,12 @@ class NodesRoute(routes.Route):
     __controller__ = controllers.NodesController
 
     refresh_secret = routes.action(RefreshSecretAction, invoke=True)
+
+
+class NodeVerifiersRoute(routes.Route):
+    """Handler for /v1/node_verifiers/ endpoint"""
+
+    __allow_methods__ = [routes.GET]
+    __controller__ = controllers.NodeVerifierController
+
+    verify = routes.action(NodeVerifierVerifyAction)

--- a/gcl_sdk/migrations/0006-ua-node-verifier-view-7c852b.py
+++ b/gcl_sdk/migrations/0006-ua-node-verifier-view-7c852b.py
@@ -1,0 +1,48 @@
+#    Copyright 2025-2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from restalchemy.storage.sql import migrations
+
+
+class MigrationStep(migrations.AbstractMigrationStep):
+    def __init__(self):
+        self._depends = ["0005-ua-api-encryption-keys-2f8d3a.py"]
+
+    @property
+    def migration_id(self):
+        return "7c852bde-ca9b-47c3-ad2d-eb1fbe6d8f23"
+
+    @property
+    def is_manual(self):
+        return False
+
+    def upgrade(self, session):
+        # Create a view on ua_node_encryption_keys table
+        # exposing only the uuid column for node verification
+        session.execute(
+            """CREATE OR REPLACE VIEW ua_node_verifiers_view AS
+                SELECT uuid FROM ua_node_encryption_keys;""",
+            None,
+        )
+
+    def downgrade(self, session):
+        # Drop the view
+        session.execute(
+            "DROP VIEW IF EXISTS ua_node_verifiers_view;",
+            None,
+        )
+
+
+migration_step = MigrationStep()

--- a/gcl_sdk/tests/functional/agents/test_universal_agent.py
+++ b/gcl_sdk/tests/functional/agents/test_universal_agent.py
@@ -138,6 +138,47 @@ class TestUniversalAgent:
         assert set(updated_agent.capabilities["capabilities"]) == {"foo"}
         assert set(updated_agent.facts["facts"]) == {"foo"}
 
+    def test_agent_registration_node_not_found(self):
+        """Test that NodeNotFound exception is handled and logged during registration."""
+        self.orch_client.agents_create = mock.MagicMock(
+            side_effect=orch_exc.NodeNotFound(uuid=self.agent_uuid)
+        )
+
+        agent = agent_svc.UniversalAgentService(
+            agent_uuid=self.agent_uuid,
+            orch_client=self.orch_client,
+            caps_drivers=[],
+            facts_drivers=[],
+            verify_node_on_register=True,
+        )
+
+        # Should not raise, just log warning
+        agent._setup()
+
+        self.orch_client.agents_create.assert_called_once()
+        # Verify check_node_exists was passed as True
+        call_kwargs = self.orch_client.agents_create.call_args.kwargs
+        assert call_kwargs.get("check_node_exists") is True
+
+    def test_agent_registration_skip_node_verify(self):
+        """Test that node verification can be skipped."""
+        self.orch_client.agents_create = mock.MagicMock(return_value=None)
+
+        agent = agent_svc.UniversalAgentService(
+            agent_uuid=self.agent_uuid,
+            orch_client=self.orch_client,
+            caps_drivers=[],
+            facts_drivers=[],
+            verify_node_on_register=False,
+        )
+
+        agent._setup()
+
+        self.orch_client.agents_create.assert_called_once()
+        # Verify check_node_exists was passed as False
+        call_kwargs = self.orch_client.agents_create.call_args.kwargs
+        assert call_kwargs.get("check_node_exists") is False
+
     def test_agent_new_capability(self):
         uuid = sys_uuid.uuid4()
         resource = conftest.FooResource(uuid=uuid)

--- a/gcl_sdk/tests/functional/conftest.py
+++ b/gcl_sdk/tests/functional/conftest.py
@@ -233,6 +233,7 @@ def status_api_wsgi_app():
         __allow_methods__ = [routes.FILTER]
 
         agents = routes.route(status_routes.UniversalAgentsRoute)
+        node_verifiers = routes.route(status_routes.NodeVerifiersRoute)
         kind = routes.route(status_routes.KindRoute)
 
     setattr(

--- a/gcl_sdk/tests/functional/restapi/test_status_api.py
+++ b/gcl_sdk/tests/functional/restapi/test_status_api.py
@@ -210,3 +210,37 @@ class TestUAStatusApi:
 
         assert response.status_code == 200
         assert output == ["foo"]
+
+    def test_node_verifier_verify_exists_true(
+        self,
+        status_api: test_utils.RestServiceTestCase,
+    ):
+        """Test verify returns valid=True when node encryption key exists."""
+        node_uuid = sys_uuid.uuid4()
+
+        # Create NodeEncryptionKey
+        node_key = models.NodeEncryptionKey(
+            uuid=node_uuid,
+            private_key="test-key",
+        )
+        node_key.save()
+
+        url = urljoin(status_api.base_url, f"node_verifiers/{node_uuid}/actions/verify")
+        response = requests.get(url)
+        output = response.json()
+
+        assert response.status_code == 200
+        assert output == {"valid": True}
+
+    def test_node_verifier_verify_not_found(
+        self,
+        status_api: test_utils.RestServiceTestCase,
+    ):
+        """Test verify returns 404 when node encryption key doesn't exist."""
+        node_uuid = sys_uuid.uuid4()
+
+        url = urljoin(status_api.base_url, f"node_verifiers/{node_uuid}/actions/verify")
+        response = requests.get(url)
+
+        # The framework returns 404 when the resource is not found
+        assert response.status_code == 404

--- a/gcl_sdk/tests/unit/agents/clients/test_status_client.py
+++ b/gcl_sdk/tests/unit/agents/clients/test_status_client.py
@@ -1,0 +1,61 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import annotations
+
+import uuid as sys_uuid
+from unittest import mock
+
+
+from gcl_sdk.agents.universal.clients.http import status as status_client
+
+
+NODE_UUID = sys_uuid.UUID("55c6968c-d26e-58a3-cfe2-11afde248319")
+
+
+class TestNodeVerifiersClient:
+    """Tests for NodeVerifiersClient."""
+
+    def setup_method(self):
+        self.client = status_client.NodeVerifiersClient(
+            "http://localhost:8080",
+            http_client=mock.MagicMock(),
+        )
+
+    def test_verify_exists_true(self):
+        """Test verify returns True when node exists."""
+        self.client.do_action = mock.MagicMock(return_value={"valid": True})
+
+        result = self.client.verify(NODE_UUID)
+
+        assert result is True
+        self.client.do_action.assert_called_once_with("verify", NODE_UUID)
+
+    def test_verify_exists_false(self):
+        """Test verify returns False when node doesn't exist."""
+        self.client.do_action = mock.MagicMock(return_value={"valid": False})
+
+        result = self.client.verify(NODE_UUID)
+
+        assert result is False
+        self.client.do_action.assert_called_once_with("verify", NODE_UUID)
+
+    def test_verify_default_false(self):
+        """Test verify returns False when valid key is missing."""
+        self.client.do_action = mock.MagicMock(return_value={})
+
+        result = self.client.verify(NODE_UUID)
+
+        assert result is False


### PR DESCRIPTION
feat: add NodeVerifier controller for node verification

Adds a dedicated NodeVerifier model/controller for checking node
existence during agent registration. 

Changes:
- New ua_node_verifiers_view (SQL view on ua_node_encryption_keys)
- New endpoint: /v1/node_verifiers/<uuid>/actions/verify
- Updated orch clients to use new verification endpoint
- Added migration for the SQL view
- Updated tests for new endpoint path