### PR TITLE
fix(agents): make UniversalAgent.status read-only, server-controlled

### DIFF
--- a/gcl_sdk/agents/universal/clients/http/status.py
+++ b/gcl_sdk/agents/universal/clients/http/status.py
@@ -28,18 +28,6 @@ class UniversalAgentsClient(base.StaticCollectionBaseModelClient):
     __collection_path__ = "/v1/agents/"
     __model__ = models.UniversalAgent
 
-    def create(self, object: models.UniversalAgent) -> models.UniversalAgent:
-        """Create the agent without sending its self-reported status.
-
-        `status` is server-controlled, even the initial one (see
-        UniversalAgentsController.create()) - the server would reject a
-        present `status` field outright since it's read-only over the API.
-        """
-        data = object.dump_to_simple_view(skip=("status",))
-        return self.__model__.restore_from_simple_view(
-            **base.CollectionBaseClient.create(self, self.get_collection(), data)
-        )
-
 
 class NodeVerifiersClient(base.StaticCollectionBaseModelClient):
     __collection_path__ = "/v1/node_verifiers/"

--- a/gcl_sdk/agents/universal/clients/http/status.py
+++ b/gcl_sdk/agents/universal/clients/http/status.py
@@ -28,6 +28,18 @@ class UniversalAgentsClient(base.StaticCollectionBaseModelClient):
     __collection_path__ = "/v1/agents/"
     __model__ = models.UniversalAgent
 
+    def create(self, object: models.UniversalAgent) -> models.UniversalAgent:
+        """Create the agent without sending its self-reported status.
+
+        `status` is server-controlled, even the initial one (see
+        UniversalAgentsController.create()) - the server would reject a
+        present `status` field outright since it's read-only over the API.
+        """
+        data = object.dump_to_simple_view(skip=("status",))
+        return self.__model__.restore_from_simple_view(
+            **base.CollectionBaseClient.create(self, self.get_collection(), data)
+        )
+
 
 class NodeVerifiersClient(base.StaticCollectionBaseModelClient):
     __collection_path__ = "/v1/node_verifiers/"

--- a/gcl_sdk/agents/universal/clients/orch/db.py
+++ b/gcl_sdk/agents/universal/clients/orch/db.py
@@ -105,12 +105,10 @@ class DatabaseOrchClient(base.AbstractOrchClient):
                 origin_agent.facts = agent.facts
                 origin_agent.name = agent.name
 
-                # `status` is read-only (see UniversalAgent.status) - this
-                # client is a trusted in-process caller, so it activates the
-                # agent directly instead of going through the API.
-                origin_agent.properties["status"].set_value_force(
-                    c.AgentStatus.ACTIVE.value
-                )
+                # `status` is read-only over the API (see
+                # UniversalAgentsController) - this client talks to the DB
+                # directly, so it activates the agent itself the same way.
+                origin_agent.status = c.AgentStatus.ACTIVE.value
 
                 origin_agent.save()
 

--- a/gcl_sdk/agents/universal/clients/orch/db.py
+++ b/gcl_sdk/agents/universal/clients/orch/db.py
@@ -24,6 +24,7 @@ from restalchemy.common import contexts
 from restalchemy.dm import filters as dm_filters
 from restalchemy.storage import exceptions as ra_exc
 
+from gcl_sdk.agents.universal import constants as c
 from gcl_sdk.agents.universal.clients.orch import base
 from gcl_sdk.agents.universal.clients.orch import exceptions
 from gcl_sdk.agents.universal.dm import models
@@ -103,6 +104,13 @@ class DatabaseOrchClient(base.AbstractOrchClient):
                 origin_agent.capabilities = agent.capabilities
                 origin_agent.facts = agent.facts
                 origin_agent.name = agent.name
+
+                # `status` is read-only (see UniversalAgent.status) - this
+                # client is a trusted in-process caller, so it activates the
+                # agent directly instead of going through the API.
+                origin_agent.properties["status"].set_value_force(
+                    c.AgentStatus.ACTIVE.value
+                )
 
                 origin_agent.save()
 

--- a/gcl_sdk/agents/universal/dm/models.py
+++ b/gcl_sdk/agents/universal/dm/models.py
@@ -272,9 +272,13 @@ class UniversalAgent(
     capabilities = properties.property(types.Dict(), default=dict)
     facts = properties.property(types.Dict(), default=dict)
     node = properties.property(types.UUID(), required=True)
+    # Read-only over the API - only the server (see UniversalAgentsController)
+    # or a trusted in-process client (see DatabaseOrchClient) may transition
+    # it, never the agent's own self-reported value.
     status = properties.property(
         types.Enum([s.value for s in c.AgentStatus]),
         default=c.AgentStatus.NEW.value,
+        read_only=True,
     )
 
     @property

--- a/gcl_sdk/agents/universal/dm/models.py
+++ b/gcl_sdk/agents/universal/dm/models.py
@@ -272,13 +272,9 @@ class UniversalAgent(
     capabilities = properties.property(types.Dict(), default=dict)
     facts = properties.property(types.Dict(), default=dict)
     node = properties.property(types.UUID(), required=True)
-    # Read-only over the API - only the server (see UniversalAgentsController)
-    # or a trusted in-process client (see DatabaseOrchClient) may transition
-    # it, never the agent's own self-reported value.
     status = properties.property(
         types.Enum([s.value for s in c.AgentStatus]),
         default=c.AgentStatus.NEW.value,
-        read_only=True,
     )
 
     @property

--- a/gcl_sdk/agents/universal/orch_api/controllers.py
+++ b/gcl_sdk/agents/universal/orch_api/controllers.py
@@ -13,9 +13,14 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import uuid as sys_uuid
+
 from restalchemy.api import actions
+from restalchemy.api import constants as ra_c
+from restalchemy.api import field_permissions as field_p
 from restalchemy.api import resources
 
+from gcl_sdk.agents.universal import constants as c
 from gcl_sdk.agents.universal.api import controllers as sdk_controllers
 from gcl_sdk.agents.universal.dm import models
 
@@ -27,7 +32,37 @@ class UniversalAgentsController(sdk_controllers.BaseSdkResourceController):
         model_class=models.UniversalAgent,
         process_filters=True,
         convert_underscore=False,
+        fields_permissions=field_p.FieldsPermissions(
+            default=field_p.Permissions.RW,
+            fields={
+                "status": {ra_c.ALL: field_p.Permissions.RO},
+            },
+        ),
     )
+
+    def create(self, **kwargs):
+        """Create the agent, always starting it ACTIVE.
+
+        `status` is read-only over the API - the server decides it, even
+        the initial one, instead of trusting the registering agent's own
+        (client-side default) value. The client itself must not send it
+        either (see UniversalAgentsClient.create()), since this field is
+        read-only for CREATE too and a present-but-ignored value would
+        still be rejected by the RA request unpacker.
+        """
+        kwargs["status"] = c.AgentStatus.ACTIVE.value
+        return super().create(**kwargs)
+
+    def update(self, uuid: sys_uuid.UUID, **kwargs):
+        """Update the agent, always (re)activating it.
+
+        `status` is read-only over the API - an agent successfully calling
+        this endpoint (e.g. on re-registration) is what proves it's alive,
+        so the server activates it here rather than trusting a client-
+        supplied `status` value.
+        """
+        kwargs["status"] = c.AgentStatus.ACTIVE.value
+        return super().update(uuid, **kwargs)
 
     @actions.get
     def get_payload(

--- a/gcl_sdk/agents/universal/orch_api/controllers.py
+++ b/gcl_sdk/agents/universal/orch_api/controllers.py
@@ -35,7 +35,10 @@ class UniversalAgentsController(sdk_controllers.BaseSdkResourceController):
         fields_permissions=field_p.FieldsPermissions(
             default=field_p.Permissions.RW,
             fields={
-                "status": {ra_c.ALL: field_p.Permissions.RO},
+                # UPDATE only - CREATE stays RW so older clients that still
+                # send their own initial status keep working: the value is
+                # simply overridden below, not rejected.
+                "status": {ra_c.UPDATE: field_p.Permissions.RO},
             },
         ),
     )
@@ -43,12 +46,10 @@ class UniversalAgentsController(sdk_controllers.BaseSdkResourceController):
     def create(self, **kwargs):
         """Create the agent, always starting it ACTIVE.
 
-        `status` is read-only over the API - the server decides it, even
-        the initial one, instead of trusting the registering agent's own
-        (client-side default) value. The client itself must not send it
-        either (see UniversalAgentsClient.create()), since this field is
-        read-only for CREATE too and a present-but-ignored value would
-        still be rejected by the RA request unpacker.
+        The server decides the initial status, not the registering agent's
+        own (client-side default) value. A client-supplied `status` is
+        simply overridden here rather than rejected, so older clients that
+        still send one don't break.
         """
         kwargs["status"] = c.AgentStatus.ACTIVE.value
         return super().create(**kwargs)

--- a/gcl_sdk/agents/universal/status_api/controllers.py
+++ b/gcl_sdk/agents/universal/status_api/controllers.py
@@ -16,6 +16,8 @@
 import uuid as sys_uuid
 
 from restalchemy.api import actions
+from restalchemy.api import constants as ra_c
+from restalchemy.api import field_permissions as field_p
 from restalchemy.api import resources
 from restalchemy.dm import filters as dm_filters
 
@@ -68,6 +70,12 @@ class UniversalAgentsController(sdk_controllers.BaseSdkResourceController):
         model_class=models.UniversalAgent,
         process_filters=True,
         convert_underscore=False,
+        fields_permissions=field_p.FieldsPermissions(
+            default=field_p.Permissions.RW,
+            fields={
+                "status": {ra_c.ALL: field_p.Permissions.RO},
+            },
+        ),
     )
 
     def update(self, uuid: sys_uuid.UUID, **kwargs):
@@ -78,12 +86,8 @@ class UniversalAgentsController(sdk_controllers.BaseSdkResourceController):
         so the server activates it here rather than trusting a client-
         supplied `status` value.
         """
-        agent = self.get(uuid=uuid)
-        kwargs = self._apply_autovalues(kwargs)
-        agent.update_dm(values=kwargs)
-        agent.properties["status"].set_value_force(c.AgentStatus.ACTIVE.value)
-        agent.update()
-        return agent
+        kwargs["status"] = c.AgentStatus.ACTIVE.value
+        return super().update(uuid, **kwargs)
 
 
 class NodeVerifierController(sdk_controllers.BaseSdkResourceController):

--- a/gcl_sdk/agents/universal/status_api/controllers.py
+++ b/gcl_sdk/agents/universal/status_api/controllers.py
@@ -73,13 +73,23 @@ class UniversalAgentsController(sdk_controllers.BaseSdkResourceController):
         fields_permissions=field_p.FieldsPermissions(
             default=field_p.Permissions.RW,
             fields={
-                # UPDATE only - CREATE must still accept it, since a fresh
-                # agent's registration payload always includes its own
-                # (client-chosen) initial status.
-                "status": {ra_c.UPDATE: field_p.Permissions.RO},
+                "status": {ra_c.ALL: field_p.Permissions.RO},
             },
         ),
     )
+
+    def create(self, **kwargs):
+        """Create the agent, always starting it ACTIVE.
+
+        `status` is read-only over the API - the server decides it, even
+        the initial one, instead of trusting the registering agent's own
+        (client-side default) value. The client itself must not send it
+        either (see UniversalAgentsClient.create()), since this field is
+        read-only for CREATE too and a present-but-ignored value would
+        still be rejected by the RA request unpacker.
+        """
+        kwargs["status"] = c.AgentStatus.ACTIVE.value
+        return super().create(**kwargs)
 
     def update(self, uuid: sys_uuid.UUID, **kwargs):
         """Update the agent, always (re)activating it.

--- a/gcl_sdk/agents/universal/status_api/controllers.py
+++ b/gcl_sdk/agents/universal/status_api/controllers.py
@@ -73,7 +73,10 @@ class UniversalAgentsController(sdk_controllers.BaseSdkResourceController):
         fields_permissions=field_p.FieldsPermissions(
             default=field_p.Permissions.RW,
             fields={
-                "status": {ra_c.ALL: field_p.Permissions.RO},
+                # UPDATE only - CREATE stays RW so older clients that still
+                # send their own initial status keep working: the value is
+                # simply overridden below, not rejected.
+                "status": {ra_c.UPDATE: field_p.Permissions.RO},
             },
         ),
     )
@@ -81,12 +84,10 @@ class UniversalAgentsController(sdk_controllers.BaseSdkResourceController):
     def create(self, **kwargs):
         """Create the agent, always starting it ACTIVE.
 
-        `status` is read-only over the API - the server decides it, even
-        the initial one, instead of trusting the registering agent's own
-        (client-side default) value. The client itself must not send it
-        either (see UniversalAgentsClient.create()), since this field is
-        read-only for CREATE too and a present-but-ignored value would
-        still be rejected by the RA request unpacker.
+        The server decides the initial status, not the registering agent's
+        own (client-side default) value. A client-supplied `status` is
+        simply overridden here rather than rejected, so older clients that
+        still send one don't break.
         """
         kwargs["status"] = c.AgentStatus.ACTIVE.value
         return super().create(**kwargs)

--- a/gcl_sdk/agents/universal/status_api/controllers.py
+++ b/gcl_sdk/agents/universal/status_api/controllers.py
@@ -19,6 +19,7 @@ from restalchemy.api import actions
 from restalchemy.api import resources
 from restalchemy.dm import filters as dm_filters
 
+from gcl_sdk.agents.universal import constants as c
 from gcl_sdk.agents.universal.api import controllers as sdk_controllers
 from gcl_sdk.agents.universal.api import crypto
 from gcl_sdk.agents.universal.status_api.dm import models
@@ -68,6 +69,21 @@ class UniversalAgentsController(sdk_controllers.BaseSdkResourceController):
         process_filters=True,
         convert_underscore=False,
     )
+
+    def update(self, uuid: sys_uuid.UUID, **kwargs):
+        """Update the agent, always (re)activating it.
+
+        `status` is read-only over the API - an agent successfully calling
+        this endpoint (e.g. on re-registration) is what proves it's alive,
+        so the server activates it here rather than trusting a client-
+        supplied `status` value.
+        """
+        agent = self.get(uuid=uuid)
+        kwargs = self._apply_autovalues(kwargs)
+        agent.update_dm(values=kwargs)
+        agent.properties["status"].set_value_force(c.AgentStatus.ACTIVE.value)
+        agent.update()
+        return agent
 
 
 class NodeVerifierController(sdk_controllers.BaseSdkResourceController):

--- a/gcl_sdk/agents/universal/status_api/controllers.py
+++ b/gcl_sdk/agents/universal/status_api/controllers.py
@@ -73,7 +73,10 @@ class UniversalAgentsController(sdk_controllers.BaseSdkResourceController):
         fields_permissions=field_p.FieldsPermissions(
             default=field_p.Permissions.RW,
             fields={
-                "status": {ra_c.ALL: field_p.Permissions.RO},
+                # UPDATE only - CREATE must still accept it, since a fresh
+                # agent's registration payload always includes its own
+                # (client-chosen) initial status.
+                "status": {ra_c.UPDATE: field_p.Permissions.RO},
             },
         ),
     )

--- a/gcl_sdk/tests/unit/agents/clients/test_orch_db_client.py
+++ b/gcl_sdk/tests/unit/agents/clients/test_orch_db_client.py
@@ -1,0 +1,58 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import uuid as sys_uuid
+from unittest import mock
+
+from gcl_sdk.agents.universal import constants as c
+from gcl_sdk.agents.universal.clients.orch import db as orch_db
+from gcl_sdk.agents.universal.dm import models
+
+
+class TestDatabaseOrchClientAgentsUpdate:
+    def test_agents_update_activates_the_agent(self):
+        # A re-registering agent (uuid already exists) goes through this
+        # path - it must always end up ACTIVE, since `status` is read-only
+        # (see UniversalAgent.status) and this client is the trusted
+        # in-process caller responsible for activating it directly.
+        client = orch_db.DatabaseOrchClient()
+        agent_uuid = sys_uuid.uuid4()
+
+        incoming = models.UniversalAgent(
+            uuid=agent_uuid,
+            name="new-name",
+            node=sys_uuid.uuid4(),
+            capabilities={"capabilities": ["pool"]},
+            facts={"facts": []},
+        )
+        origin_agent = models.UniversalAgent(
+            uuid=agent_uuid,
+            name="old-name",
+            node=sys_uuid.uuid4(),
+            status=c.AgentStatus.NEW.value,
+        )
+
+        with (
+            mock.patch.object(
+                models.UniversalAgent._ObjectCollection,
+                "get_one",
+                return_value=origin_agent,
+            ),
+            mock.patch.object(origin_agent, "save"),
+        ):
+            result = client.agents_update(incoming, session=mock.MagicMock())
+
+        assert result.status == c.AgentStatus.ACTIVE.value

--- a/gcl_sdk/tests/unit/agents/clients/test_orch_db_client.py
+++ b/gcl_sdk/tests/unit/agents/clients/test_orch_db_client.py
@@ -25,9 +25,9 @@ from gcl_sdk.agents.universal.dm import models
 class TestDatabaseOrchClientAgentsUpdate:
     def test_agents_update_activates_the_agent(self):
         # A re-registering agent (uuid already exists) goes through this
-        # path - it must always end up ACTIVE, since `status` is read-only
-        # (see UniversalAgent.status) and this client is the trusted
-        # in-process caller responsible for activating it directly.
+        # path - it must always end up ACTIVE. `status` is read-only over
+        # the API (see UniversalAgentsController), but this client talks to
+        # the DB directly, so it's the one responsible for activating it.
         client = orch_db.DatabaseOrchClient()
         agent_uuid = sys_uuid.uuid4()
 

--- a/gcl_sdk/tests/unit/agents/clients/test_orch_http_client.py
+++ b/gcl_sdk/tests/unit/agents/clients/test_orch_http_client.py
@@ -1,0 +1,57 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import annotations
+
+from unittest import mock
+import uuid as sys_uuid
+
+from gcl_sdk.agents.universal.clients.orch import http as orch_http
+from gcl_sdk.agents.universal.dm import models
+
+
+class TestHttpOrchClientAgentsUpdate:
+    """Tests for HttpOrchClient.agents_update.
+
+    `status` is read-only over the API (see UniversalAgent.status) - the
+    client must not send its own self-reported value. The server activates
+    a re-registering agent itself (see UniversalAgentsController.update).
+    """
+
+    def setup_method(self):
+        self.client = orch_http.HttpOrchClient(
+            orch_endpoint="http://localhost:11011",
+            status_endpoint="http://localhost:11012",
+            http_client=mock.MagicMock(),
+        )
+        self.client._status_api = mock.MagicMock()
+
+    def test_agents_update_does_not_send_status(self):
+        agent = models.UniversalAgent.from_system_uuid(
+            capabilities=["pool", "local_pool"],
+            facts=[],
+            agent_uuid=sys_uuid.uuid4(),
+            system_uuid=sys_uuid.uuid4(),
+        )
+        self.client._status_api.agents.update.return_value = agent
+
+        self.client.agents_update(agent)
+
+        self.client._status_api.agents.update.assert_called_once_with(
+            agent.uuid,
+            capabilities=agent.capabilities,
+            facts=agent.facts,
+            name=agent.name,
+        )

--- a/gcl_sdk/tests/unit/agents/clients/test_orch_http_client.py
+++ b/gcl_sdk/tests/unit/agents/clients/test_orch_http_client.py
@@ -25,9 +25,9 @@ from gcl_sdk.agents.universal.dm import models
 class TestHttpOrchClientAgentsUpdate:
     """Tests for HttpOrchClient.agents_update.
 
-    `status` is read-only over the API (see UniversalAgent.status) - the
-    client must not send its own self-reported value. The server activates
-    a re-registering agent itself (see UniversalAgentsController.update).
+    `status` is read-only over the API (see UniversalAgentsController) -
+    the client must not send its own self-reported value. The server
+    activates a re-registering agent itself instead.
     """
 
     def setup_method(self):

--- a/gcl_sdk/tests/unit/agents/clients/test_status_client.py
+++ b/gcl_sdk/tests/unit/agents/clients/test_status_client.py
@@ -19,44 +19,8 @@ from unittest import mock
 import uuid as sys_uuid
 
 from gcl_sdk.agents.universal.clients.http import status as status_client
-from gcl_sdk.agents.universal.dm import models
-from gcl_sdk.clients.http import base
 
 NODE_UUID = sys_uuid.UUID("55c6968c-d26e-58a3-cfe2-11afde248319")
-
-
-class TestUniversalAgentsClientCreate:
-    """Tests for UniversalAgentsClient.create.
-
-    `status` is server-controlled, even the initial one (see
-    UniversalAgentsController.create()) - the client must not send it, or
-    the server rejects the whole request (the field is read-only over the
-    API).
-    """
-
-    def setup_method(self):
-        self.client = status_client.UniversalAgentsClient(
-            "http://localhost:8080",
-            http_client=mock.MagicMock(),
-        )
-
-    def test_create_does_not_send_status(self):
-        agent = models.UniversalAgent.from_system_uuid(
-            capabilities=["pool"],
-            facts=[],
-            agent_uuid=sys_uuid.uuid4(),
-            system_uuid=sys_uuid.uuid4(),
-        )
-
-        with mock.patch.object(
-            base.CollectionBaseClient,
-            "create",
-            return_value=agent.dump_to_simple_view(),
-        ) as mock_create:
-            self.client.create(agent)
-
-        sent_data = mock_create.call_args[0][2]
-        assert "status" not in sent_data
 
 
 class TestNodeVerifiersClient:

--- a/gcl_sdk/tests/unit/agents/clients/test_status_client.py
+++ b/gcl_sdk/tests/unit/agents/clients/test_status_client.py
@@ -19,8 +19,44 @@ from unittest import mock
 import uuid as sys_uuid
 
 from gcl_sdk.agents.universal.clients.http import status as status_client
+from gcl_sdk.agents.universal.dm import models
+from gcl_sdk.clients.http import base
 
 NODE_UUID = sys_uuid.UUID("55c6968c-d26e-58a3-cfe2-11afde248319")
+
+
+class TestUniversalAgentsClientCreate:
+    """Tests for UniversalAgentsClient.create.
+
+    `status` is server-controlled, even the initial one (see
+    UniversalAgentsController.create()) - the client must not send it, or
+    the server rejects the whole request (the field is read-only over the
+    API).
+    """
+
+    def setup_method(self):
+        self.client = status_client.UniversalAgentsClient(
+            "http://localhost:8080",
+            http_client=mock.MagicMock(),
+        )
+
+    def test_create_does_not_send_status(self):
+        agent = models.UniversalAgent.from_system_uuid(
+            capabilities=["pool"],
+            facts=[],
+            agent_uuid=sys_uuid.uuid4(),
+            system_uuid=sys_uuid.uuid4(),
+        )
+
+        with mock.patch.object(
+            base.CollectionBaseClient,
+            "create",
+            return_value=agent.dump_to_simple_view(),
+        ) as mock_create:
+            self.client.create(agent)
+
+        sent_data = mock_create.call_args[0][2]
+        assert "status" not in sent_data
 
 
 class TestNodeVerifiersClient:

--- a/gcl_sdk/tests/unit/agents/orch_api/test_controllers.py
+++ b/gcl_sdk/tests/unit/agents/orch_api/test_controllers.py
@@ -1,0 +1,81 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import uuid as sys_uuid
+from unittest import mock
+
+from restalchemy.api import constants as ra_c
+from restalchemy.api import contexts
+from webob.request import Request
+
+from gcl_sdk.agents.universal import constants as c
+from gcl_sdk.agents.universal.dm import models
+from gcl_sdk.agents.universal.orch_api import controllers
+
+
+def _req_for_method(method):
+    req = Request(environ={})
+    req.api_context = contexts.RequestContext(req)
+    req.api_context.set_active_method(method)
+    return req
+
+
+class TestUniversalAgentsControllerFieldPermissions:
+    def test_status_is_read_only_for_create_and_update(self):
+        perms = controllers.UniversalAgentsController.__resource__._fields_permissions
+
+        assert perms.is_readonly("status", _req_for_method(ra_c.CREATE)) is True
+        assert perms.is_readonly("status", _req_for_method(ra_c.UPDATE)) is True
+
+
+class TestUniversalAgentsControllerCreate:
+    def test_create_always_starts_the_agent_active(self):
+        # A client can never set the agent's initial status either - the
+        # server decides it, same as on update.
+        controller = controllers.UniversalAgentsController(mock.MagicMock())
+
+        with mock.patch.object(models.UniversalAgent, "insert"):
+            result = controller.create(
+                uuid=sys_uuid.uuid4(),
+                name="agent",
+                node=sys_uuid.uuid4(),
+                status=c.AgentStatus.DISABLED.value,
+            )
+
+        assert result.status == c.AgentStatus.ACTIVE.value
+
+
+class TestUniversalAgentsControllerUpdate:
+    def test_update_always_activates_the_agent(self):
+        # A re-registering agent (e.g. after its capabilities changed) goes
+        # through this path - it must always end up ACTIVE, regardless of
+        # what status it was in before or what the client sends, since
+        # `status` is read-only over the API (see the controller's
+        # fields_permissions) even though the underlying model field itself
+        # stays freely writable for other in-process code (builders, etc).
+        controller = controllers.UniversalAgentsController(mock.MagicMock())
+        agent = mock.MagicMock()
+        uuid = sys_uuid.uuid4()
+
+        with mock.patch.object(controller, "get", return_value=agent) as mock_get:
+            result = controller.update(uuid, name="new-name")
+
+        mock_get.assert_called_once_with(uuid=uuid)
+        agent.update_dm.assert_called_once_with(
+            values={"name": "new-name", "status": c.AgentStatus.ACTIVE.value}
+        )
+        agent.update.assert_called_once_with()
+        assert result is agent

--- a/gcl_sdk/tests/unit/agents/orch_api/test_controllers.py
+++ b/gcl_sdk/tests/unit/agents/orch_api/test_controllers.py
@@ -34,17 +34,22 @@ def _req_for_method(method):
 
 
 class TestUniversalAgentsControllerFieldPermissions:
-    def test_status_is_read_only_for_create_and_update(self):
+    def test_status_is_read_only_for_update_only(self):
+        # CREATE stays RW: older clients that still send their own initial
+        # status (e.g. exordos_seed) must not get their request rejected -
+        # the controller overrides the value instead (see
+        # TestUniversalAgentsControllerCreate).
         perms = controllers.UniversalAgentsController.__resource__._fields_permissions
 
-        assert perms.is_readonly("status", _req_for_method(ra_c.CREATE)) is True
+        assert perms.is_readonly("status", _req_for_method(ra_c.CREATE)) is False
         assert perms.is_readonly("status", _req_for_method(ra_c.UPDATE)) is True
 
 
 class TestUniversalAgentsControllerCreate:
     def test_create_always_starts_the_agent_active(self):
-        # A client can never set the agent's initial status either - the
-        # server decides it, same as on update.
+        # A client-supplied status (e.g. from an older client that still
+        # sends one) must not be rejected - it's simply overridden, same
+        # end result as on update.
         controller = controllers.UniversalAgentsController(mock.MagicMock())
 
         with mock.patch.object(models.UniversalAgent, "insert"):

--- a/gcl_sdk/tests/unit/agents/status_api/test_controllers.py
+++ b/gcl_sdk/tests/unit/agents/status_api/test_controllers.py
@@ -26,7 +26,9 @@ class TestUniversalAgentsControllerUpdate:
         # A re-registering agent (e.g. after its capabilities changed) goes
         # through this path - it must always end up ACTIVE, regardless of
         # what status it was in before or what the client sends, since
-        # `status` is read-only over the API (see UniversalAgent.status).
+        # `status` is read-only over the API (see the controller's
+        # fields_permissions) even though the underlying model field itself
+        # stays freely writable for other in-process code (builders, etc).
         controller = controllers.UniversalAgentsController(mock.MagicMock())
         agent = mock.MagicMock()
         uuid = sys_uuid.uuid4()
@@ -35,9 +37,8 @@ class TestUniversalAgentsControllerUpdate:
             result = controller.update(uuid, name="new-name")
 
         mock_get.assert_called_once_with(uuid=uuid)
-        agent.update_dm.assert_called_once_with(values={"name": "new-name"})
-        agent.properties["status"].set_value_force.assert_called_once_with(
-            c.AgentStatus.ACTIVE.value
+        agent.update_dm.assert_called_once_with(
+            values={"name": "new-name", "status": c.AgentStatus.ACTIVE.value}
         )
         agent.update.assert_called_once_with()
         assert result is agent

--- a/gcl_sdk/tests/unit/agents/status_api/test_controllers.py
+++ b/gcl_sdk/tests/unit/agents/status_api/test_controllers.py
@@ -17,8 +17,30 @@
 import uuid as sys_uuid
 from unittest import mock
 
+from restalchemy.api import constants as ra_c
+from restalchemy.api import contexts
+from webob.request import Request
+
 from gcl_sdk.agents.universal import constants as c
 from gcl_sdk.agents.universal.status_api import controllers
+
+
+def _req_for_method(method):
+    req = Request(environ={})
+    req.api_context = contexts.RequestContext(req)
+    req.api_context.set_active_method(method)
+    return req
+
+
+class TestUniversalAgentsControllerFieldPermissions:
+    def test_status_is_read_only_for_update_only(self):
+        # Regression: a blanket ra_c.ALL RO permission also covers CREATE,
+        # which would reject agent registration outright - a fresh agent's
+        # register payload always includes its own initial status.
+        perms = controllers.UniversalAgentsController.__resource__._fields_permissions
+
+        assert perms.is_readonly("status", _req_for_method(ra_c.CREATE)) is False
+        assert perms.is_readonly("status", _req_for_method(ra_c.UPDATE)) is True
 
 
 class TestUniversalAgentsControllerUpdate:

--- a/gcl_sdk/tests/unit/agents/status_api/test_controllers.py
+++ b/gcl_sdk/tests/unit/agents/status_api/test_controllers.py
@@ -34,17 +34,22 @@ def _req_for_method(method):
 
 
 class TestUniversalAgentsControllerFieldPermissions:
-    def test_status_is_read_only_for_create_and_update(self):
+    def test_status_is_read_only_for_update_only(self):
+        # CREATE stays RW: older clients that still send their own initial
+        # status (e.g. exordos_seed) must not get their request rejected -
+        # the controller overrides the value instead (see
+        # TestUniversalAgentsControllerCreate).
         perms = controllers.UniversalAgentsController.__resource__._fields_permissions
 
-        assert perms.is_readonly("status", _req_for_method(ra_c.CREATE)) is True
+        assert perms.is_readonly("status", _req_for_method(ra_c.CREATE)) is False
         assert perms.is_readonly("status", _req_for_method(ra_c.UPDATE)) is True
 
 
 class TestUniversalAgentsControllerCreate:
     def test_create_always_starts_the_agent_active(self):
-        # A client can never set the agent's initial status either - the
-        # server decides it, same as on update.
+        # A client-supplied status (e.g. from an older client that still
+        # sends one) must not be rejected - it's simply overridden, same
+        # end result as on update.
         controller = controllers.UniversalAgentsController(mock.MagicMock())
 
         with mock.patch.object(status_models.UniversalAgent, "insert"):

--- a/gcl_sdk/tests/unit/agents/status_api/test_controllers.py
+++ b/gcl_sdk/tests/unit/agents/status_api/test_controllers.py
@@ -23,6 +23,7 @@ from webob.request import Request
 
 from gcl_sdk.agents.universal import constants as c
 from gcl_sdk.agents.universal.status_api import controllers
+from gcl_sdk.agents.universal.status_api.dm import models as status_models
 
 
 def _req_for_method(method):
@@ -33,14 +34,28 @@ def _req_for_method(method):
 
 
 class TestUniversalAgentsControllerFieldPermissions:
-    def test_status_is_read_only_for_update_only(self):
-        # Regression: a blanket ra_c.ALL RO permission also covers CREATE,
-        # which would reject agent registration outright - a fresh agent's
-        # register payload always includes its own initial status.
+    def test_status_is_read_only_for_create_and_update(self):
         perms = controllers.UniversalAgentsController.__resource__._fields_permissions
 
-        assert perms.is_readonly("status", _req_for_method(ra_c.CREATE)) is False
+        assert perms.is_readonly("status", _req_for_method(ra_c.CREATE)) is True
         assert perms.is_readonly("status", _req_for_method(ra_c.UPDATE)) is True
+
+
+class TestUniversalAgentsControllerCreate:
+    def test_create_always_starts_the_agent_active(self):
+        # A client can never set the agent's initial status either - the
+        # server decides it, same as on update.
+        controller = controllers.UniversalAgentsController(mock.MagicMock())
+
+        with mock.patch.object(status_models.UniversalAgent, "insert"):
+            result = controller.create(
+                uuid=sys_uuid.uuid4(),
+                name="agent",
+                node=sys_uuid.uuid4(),
+                status=c.AgentStatus.DISABLED.value,
+            )
+
+        assert result.status == c.AgentStatus.ACTIVE.value
 
 
 class TestUniversalAgentsControllerUpdate:

--- a/gcl_sdk/tests/unit/agents/status_api/test_controllers.py
+++ b/gcl_sdk/tests/unit/agents/status_api/test_controllers.py
@@ -1,0 +1,43 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import uuid as sys_uuid
+from unittest import mock
+
+from gcl_sdk.agents.universal import constants as c
+from gcl_sdk.agents.universal.status_api import controllers
+
+
+class TestUniversalAgentsControllerUpdate:
+    def test_update_always_activates_the_agent(self):
+        # A re-registering agent (e.g. after its capabilities changed) goes
+        # through this path - it must always end up ACTIVE, regardless of
+        # what status it was in before or what the client sends, since
+        # `status` is read-only over the API (see UniversalAgent.status).
+        controller = controllers.UniversalAgentsController(mock.MagicMock())
+        agent = mock.MagicMock()
+        uuid = sys_uuid.uuid4()
+
+        with mock.patch.object(controller, "get", return_value=agent) as mock_get:
+            result = controller.update(uuid, name="new-name")
+
+        mock_get.assert_called_once_with(uuid=uuid)
+        agent.update_dm.assert_called_once_with(values={"name": "new-name"})
+        agent.properties["status"].set_value_force.assert_called_once_with(
+            c.AgentStatus.ACTIVE.value
+        )
+        agent.update.assert_called_once_with()
+        assert result is agent


### PR DESCRIPTION
  - UniversalAgent.status is a normal, freely-writable model field (not read-only at the DM layer) — internal code (builders, services, DatabaseOrchClient) can still set it directly.
  - Over the REST API, status is read-only for UPDATE: UniversalAgentsController.update() (in both status_api and orch_api) always overrides the field to ACTIVE, ignoring whatever the client sends — a re-registering agent activates itself simply by successfully calling this endpoint.
  - Over the REST API, status is read-write for CREATE: a client may still include its own initial status without the request being rejected, but UniversalAgentsController.create() (in both status_api and orch_api) always overrides it to ACTIVE too. This keeps older/external clients (e.g. exordos_seed, which isn't part of this codebase) working unmodified, since their request is accepted rather than failing with FieldPermissionError.
  - HttpOrchClient.agents_update() no longer sends status in its payload (not needed — the server decides it now).
  - DatabaseOrchClient.agents_update() (the trusted in-process DB client, with no API layer in front of it) sets status = ACTIVE directly.

## Summary by Sourcery

Make the UniversalAgent.status field server-controlled and read-only over the API, ensuring agents are activated only by trusted server-side paths on update.

Bug Fixes:
- Prevent clients from arbitrarily changing UniversalAgent.status via the agents update API.

Enhancements:
- Have the UniversalAgentsController.update and DatabaseOrchClient.agents_update paths explicitly transition agents to ACTIVE on successful re-registration.
- Mark UniversalAgent.status as a read-only property to enforce server-side control over status transitions.

Tests:
- Add unit tests covering DatabaseOrchClient.agents_update to ensure it activates existing agents.
- Add unit tests for UniversalAgentsController.update to ensure it always sets agent status to ACTIVE regardless of client input.